### PR TITLE
Compare REST vs GraphQL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,9 +30,14 @@ jobs:
     - name: "REST PATCH requests stop working after restart"
       script: ./rest_patch_stops_working_after_restart.sh
       if: type != pull_request
-    - name: "Compare REST and GraphQL while crashing"
-      script: ./compare_rest_graphql_while_crashing.sh
-      if: type != pull_request
+    # Commented only because this chaos pipeline was able to interrupt save operation
+    # just in the middle of it being performed and since Weaviate doesn't have a transaction
+    # mechanism implemented then this was causing an error which is a different error then
+    # the discrepancy one, but this pipeline is really good in crashing Weaviate so we want to
+    # save it for future tests
+    # - name: "Compare REST and GraphQL while crashing"
+    #   script: ./compare_rest_graphql_while_crashing.sh
+    #   if: type != pull_request
 
 before_script:
   # login to docker at the very beginning, so we don't run into rate-limiting

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,9 @@ jobs:
     - name: "REST PATCH requests stop working after restart"
       script: ./rest_patch_stops_working_after_restart.sh
       if: type != pull_request
+    - name: "Compare REST and GraphQL while crashing"
+      script: ./compare_rest_graphql_while_crashing.sh
+      if: type != pull_request
 
 before_script:
   # login to docker at the very beginning, so we don't run into rate-limiting

--- a/apps/chaotic-killer/Dockerfile
+++ b/apps/chaotic-killer/Dockerfile
@@ -7,5 +7,6 @@ RUN ["apk", "add", "curl", "bash"]
 COPY run.sh .
 
 COPY --from=docker:latest /usr/local/bin/docker /usr/local/bin/docker
+COPY --from=docker:latest /usr/local/bin/docker-compose /usr/local/bin/docker-compose
 
 CMD ["bash", "/chaos/run.sh"]

--- a/apps/chaotic-killer/run.sh
+++ b/apps/chaotic-killer/run.sh
@@ -12,7 +12,7 @@ while true; do
     continue
   fi
 
-  sleepsec=$(python3 -c 'import random; print(random.randint(0,60))')
+  sleepsec=$(python3 -c "import random; print(random.randint(${SLEEP_START:=0},${SLEEP_END:=60}))")
   echo "waiting ${sleepsec}s for a kill"
   sleep "$sleepsec"
 

--- a/apps/chaotic-killer/run.sh
+++ b/apps/chaotic-killer/run.sh
@@ -17,6 +17,12 @@ while true; do
   sleep "$sleepsec"
 
   echo killing now
-  docker exec $CONTAINER_ID /bin/sh -c 'ps aux | grep '"'"'weaviate'"'"' | grep -v grep | awk '"'"'{print $1}'"'"' | xargs kill -9'
+  if [[ "${CHAOTIC_KILL_DOCKER}" == "y" ]]; then
+    docker-compose -f apps/weaviate/docker-compose.yml kill weaviate \
+      && docker-compose -f apps/weaviate/docker-compose.yml up weaviate -d
+  else
+    docker exec $CONTAINER_ID /bin/sh -c 'ps aux | grep '"'"'weaviate'"'"' | grep -v grep | awk '"'"'{print $1}'"'"' | xargs kill -9'
+  fi
+
 done
 

--- a/apps/compare-rest-graphql/Dockerfile
+++ b/apps/compare-rest-graphql/Dockerfile
@@ -1,0 +1,8 @@
+FROM python:3.9-slim-buster
+
+WORKDIR /workdir
+
+COPY requirements.txt .
+RUN pip3 install -r requirements.txt
+
+COPY objects-are-not-deleted.py ./

--- a/apps/compare-rest-graphql/objects-are-not-deleted.py
+++ b/apps/compare-rest-graphql/objects-are-not-deleted.py
@@ -1,0 +1,163 @@
+"""
+https://semi-technology.atlassian.net/browse/WEAVIATE-151
+"""
+
+import weaviate
+from loguru import logger
+import sys, traceback, time
+
+class DiscrepancyError(Exception):
+  """ Raised on REST and GraphQL mismatch """
+  pass
+
+def create_weaviate_schema():
+    schema = {
+        "classes": [
+            {
+                "class": "ObjectsAreNotDeleted",
+                "vectorizer": "none",
+                "vectorIndexType": "hnsw",
+                "invertedIndexConfig": {
+                  "bm25": {
+                    "b": 0.75,
+                    "k1": 1.2
+                  },
+                  "cleanupIntervalSeconds": 60,
+                  "stopwords": {
+                    "preset": "en"
+                  }
+                },
+                "properties": [
+                    {
+                        "dataType": [
+                            "string"
+                        ],
+                        "name": "description",
+                        "tokenization": "word",
+                        "indexInverted": True
+                    },
+                ]
+            },
+        ]
+    }
+    # add schema
+    if not client.schema.contains(schema):
+        client.schema.create(schema)
+
+def get_body(index: str, req_type: str):
+    return { "description": f"this is an update number: {index} with {req_type}" }
+
+def create_object_if_it_doesnt_exist(class_name: str, object_id: str):
+  try:
+    exists = client.data_object.exists(object_id)
+    if not exists:
+      client.data_object.create(get_body(0, "create"), class_name, object_id)
+  except Exception as e:
+      logger.error(f"Error adding {class_name} object - id: {object_id}")
+      logger.error(e)
+      logger.error(''.join(traceback.format_tb(e.__traceback__)))
+
+def delete_uuids(uuids, name):
+    for uuid in uuids:
+        client.data_object.delete(uuid)
+    logger.info(f"deleted {name} objects: {len(uuids)}")
+
+def search_object(object_id: str, should_exist: bool):
+    headExists = client.data_object.exists(object_id)
+    objectGetById = client.data_object.get_by_id(object_id)
+    equalId = { "path": ["id"], "operator": "Equal", "valueString": object_id }
+    objectGraphQLGet = (
+      client.query
+      .get("ObjectsAreNotDeleted", ['_additional{id}'])
+      .with_where(equalId)
+      .do()
+    )
+
+    objectRestExists = objectGetById is not None and len(objectGetById) > 0
+    objectGraphQLExists = len(objectGraphQLGet['data']['Get']['ObjectsAreNotDeleted']) > 0
+    if not (should_exist == headExists and should_exist == objectRestExists and should_exist == objectGraphQLExists):
+        return f"search {object_id}: should_exist: {should_exist} head: {headExists} rest: {objectRestExists} graphql: {objectGraphQLExists}"
+    return ""
+
+def search_objects(uuids, should_exist: bool):
+  discrepancies = []
+  for id in uuids:
+    res = search_object(id, should_exist)
+    if len(res) > 0:
+      discrepancies.append(res)
+
+  if len(discrepancies) > 0:
+    logger.error("Discrepancies:")
+    for msg in discrepancies:
+      logger.error(msg)
+    raise DiscrepancyError(f"Discrepancy between REST and GraphQL detected")
+
+def delete_all_in_batch(uuids):
+  try:
+    operands = []
+    for id in uuids:
+      operands.append({
+        'operator': 'Equal',
+        'path': ['id'],
+        'valueString': id
+      })
+    where = {
+      'operator': 'Or',
+      'operands': operands
+    }
+    client.batch.delete_objects("ObjectsAreNotDeleted", where, 'minimal', False)
+  except Exception as e:
+    logger.error(f"Error batch deleting {class_name} objects")
+    logger.error(e)
+    logger.error(''.join(traceback.format_tb(e.__traceback__)))
+    raise Exception('Error occured during batch delete')
+
+def getUUIDs(param: str):
+  if param == "1":
+    return [
+        "17e9828d-ff0a-5e47-8101-b52312345670",
+        "17e9828d-ff0a-5e47-8101-b52312345671",
+        "17e9828d-ff0a-5e47-8101-b52312345672",
+        "17e9828d-ff0a-5e47-8101-b52312345673",
+        "17e9828d-ff0a-5e47-8101-b52312345674",
+        "17e9828d-ff0a-5e47-8101-b52312345675",
+        "17e9828d-ff0a-5e47-8101-b52312345678"
+      ]
+  return [
+        "07e9828d-ff0a-5e47-8101-b52312345670",
+        "07e9828d-ff0a-5e47-8101-b52312345671",
+        "07e9828d-ff0a-5e47-8101-b52312345672",
+        "07e9828d-ff0a-5e47-8101-b52312345673",
+        "07e9828d-ff0a-5e47-8101-b52312345674",
+        "07e9828d-ff0a-5e47-8101-b52312345675",
+        "07e9828d-ff0a-5e47-8101-b52312345678"
+      ]
+
+if __name__ == "__main__":
+    max_attempts = 250
+    for attempt in range(max_attempts):
+      try:
+        client = weaviate.Client("http://localhost:8080")
+        param = sys.argv[1]
+        logger.info(f"Attempt {attempt} Running with param: {param}")
+
+        class_name = "ObjectsAreNotDeleted"
+        uuids = getUUIDs(param)
+        create_weaviate_schema()
+        loops = 100
+        for i in range(loops):
+          logger.info(f"RUN number: {i}")
+          for id in uuids:
+            create_object_if_it_doesnt_exist(class_name, id)
+          search_objects(uuids, True)
+          delete_all_in_batch(uuids)
+          search_objects(uuids, False)
+      except DiscrepancyError:
+        logger.error(sys.exc_info()[1])
+        logger.error(''.join(traceback.format_tb(sys.exc_info()[2])))
+        exit(1)
+      except Exception as e:
+        logger.info(f"Attempt {attempt}: Caught exception {e} retrying")
+        time.sleep(2)
+        attempt += 1
+

--- a/apps/compare-rest-graphql/requirements.txt
+++ b/apps/compare-rest-graphql/requirements.txt
@@ -1,0 +1,11 @@
+certifi==2022.6.15
+charset-normalizer==2.0.12
+decorator==5.1.1
+idna==3.3
+loguru==0.6.0
+requests==2.27.1
+six==1.16.0
+tqdm==4.64.0
+urllib3==1.26.9
+validators==0.18.2
+weaviate-client==3.5.1

--- a/compare_rest_graphql_while_crashing.sh
+++ b/compare_rest_graphql_while_crashing.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+set -e
+
+function wait_weaviate() {
+  echo "Wait for Weaviate to be ready"
+  for _ in {1..120}; do
+    if curl -sf -o /dev/null localhost:8080; then
+      echo "Weaviate is ready"
+      break
+    fi
+
+    echo "Weaviate is not ready, trying again in 1s"
+    sleep 1
+  done
+}
+
+echo "Building all required containers"
+( cd apps/compare-rest-graphql/ && docker build -t compare-rest-graphql . )
+( cd apps/chaotic-killer/ && docker build -t killer . )
+
+echo "Starting Weaviate..."
+#docker-compose -f apps/weaviate/docker-compose.yml up -d
+
+wait_weaviate
+
+echo "Starting the chaos script to kill Weaviate periodically (in the background)"
+docker run \
+  --network host \
+  --rm -it -d \
+  -v "$PWD:$PWD" \
+  -e "SLEEP_START=2" \
+  -e "SLEEP_END=5" \
+  -w "$PWD" \
+  -v /var/run/docker.sock:/var/run/docker.sock \
+  --name killer \
+  killer
+
+echo "Run compare script in foreground..."
+if ! docker run \
+   --network host -it compare-rest-graphql python3 objects-are-not-deleted.py 0; then
+  echo "Discrepancy"
+  exit 1
+fi
+
+echo "Script completed successfully, stop killer"
+docker rm -f killer
+
+echo "Passed!"

--- a/compare_rest_graphql_while_crashing.sh
+++ b/compare_rest_graphql_while_crashing.sh
@@ -31,6 +31,8 @@ docker run \
   -v "$PWD:$PWD" \
   -e "SLEEP_START=2" \
   -e "SLEEP_END=5" \
+  -e "WEAVIATE_VERSION=${WEAVIATE_VERSION}" \
+  -e "CHAOTIC_KILL_DOCKER=y" \
   -w "$PWD" \
   -v /var/run/docker.sock:/var/run/docker.sock \
   --name killer \
@@ -38,8 +40,11 @@ docker run \
 
 echo "Run compare script in foreground..."
 if ! docker run \
+  -e "MAX_ATTEMPTS=100" \
    --network host -it compare-rest-graphql python3 objects-are-not-deleted.py 0; then
-  echo "Discrepancy"
+  echo "Discrepancy error!"
+  echo "Stopping chaotic killer"
+  docker rm -f killer
   exit 1
 fi
 

--- a/compare_rest_graphql_while_crashing.sh
+++ b/compare_rest_graphql_while_crashing.sh
@@ -20,7 +20,7 @@ echo "Building all required containers"
 ( cd apps/chaotic-killer/ && docker build -t killer . )
 
 echo "Starting Weaviate..."
-#docker-compose -f apps/weaviate/docker-compose.yml up -d
+docker-compose -f apps/weaviate/docker-compose.yml up -d
 
 wait_weaviate
 


### PR DESCRIPTION
Added new test `compare_rest_graphql_while_crashing.sh`

It tries to generate discrepancies between REST and GraphQL by continually overwriting data and crashing Weaviate.

The `chaotic-killer` docker container was modified to use docker kill rather than kill inside the container. The reason for this was that restarts were being affected by a backoff policy when killing frequently inside the container that made things slower (perhaps part of the tini process supervisor run as part of docker).