### PR TITLE
Multi-node backup/restore CRUD chaos test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,36 +11,39 @@ env:
 
 jobs:
   include:
-    - name: "Import during constant kills/crashes"
-      script: ./import_while_crashing.sh
-      if: type != pull_request
-    - name: "Heavy object store imports while crashing"
-      script: ./import_while_crashing_no_vector.sh
-      if: type != pull_request
-    - name: "Segfault on filtered vector search (race with hash bucket compaction)"
-      script: ./segfault_filtered_vector_search.sh
-      if: type != pull_request
+    # - name: "Import during constant kills/crashes"
+    #   script: ./import_while_crashing.sh
+    #   if: type != pull_request
+    # - name: "Heavy object store imports while crashing"
+    #   script: ./import_while_crashing_no_vector.sh
+    #   if: type != pull_request
+    # - name: "Segfault on filtered vector search (race with hash bucket compaction)"
+    #   script: ./segfault_filtered_vector_search.sh
+    #   if: type != pull_request
     - name: "Backup & Restore CRUD"
       script: ./backup_and_restore_crud.sh
+      if: type != pull_request
+    - name: "Backup & Restore multi node CRUD"
+      script: ./backup_and_restore_multi_node_crud.sh
       if: type != pull_request
     - name: "Backup & Restore version compatibility"
       script: ./backup_and_restore_version_compatibility.sh
       if: type != pull_request
-    - name: "Compare Recall after import to after restart"
-      script: ./compare_recall_after_restart.sh
-      if: type != pull_request
-    - name: "Concurrent inverted index read/write"
-      script: ./concurrent_inverted_index_read_write.sh
-      if: type != pull_request
-    - name: "Consecutive create and update operations"
-      script: ./consecutive_create_and_update_operations.sh
-      if: type != pull_request
-    - name: "Batch insert mismatch"
-      script: ./batch_insert_mismatch.sh
-      if: type != pull_request
-    - name: "REST PATCH requests stop working after restart"
-      script: ./rest_patch_stops_working_after_restart.sh
-      if: type != pull_request
+    # - name: "Compare Recall after import to after restart"
+    #   script: ./compare_recall_after_restart.sh
+    #   if: type != pull_request
+    # - name: "Concurrent inverted index read/write"
+    #   script: ./concurrent_inverted_index_read_write.sh
+    #   if: type != pull_request
+    # - name: "Consecutive create and update operations"
+    #   script: ./consecutive_create_and_update_operations.sh
+    #   if: type != pull_request
+    # - name: "Batch insert mismatch"
+    #   script: ./batch_insert_mismatch.sh
+    #   if: type != pull_request
+    # - name: "REST PATCH requests stop working after restart"
+    #   script: ./rest_patch_stops_working_after_restart.sh
+    #   if: type != pull_request
     # Commented only because this chaos pipeline was able to interrupt save operation
     # just in the middle of it being performed and since Weaviate doesn't have a transaction
     # mechanism implemented then this was causing an error which is a different error then
@@ -49,9 +52,9 @@ jobs:
     # - name: "Compare REST and GraphQL while crashing"
     #   script: ./compare_rest_graphql_while_crashing.sh
     #   if: type != pull_request
-    - name: "Delete and recreate class with frequent updates"
-      script: ./delete_and_recreate_class.sh
-      if: type != pull_request
+    # - name: "Delete and recreate class with frequent updates"
+    #   script: ./delete_and_recreate_class.sh
+    #   if: type != pull_request
 
 before_script:
   # login to docker at the very beginning, so we don't run into rate-limiting

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,15 +11,15 @@ env:
 
 jobs:
   include:
-    # - name: "Import during constant kills/crashes"
-    #   script: ./import_while_crashing.sh
-    #   if: type != pull_request
-    # - name: "Heavy object store imports while crashing"
-    #   script: ./import_while_crashing_no_vector.sh
-    #   if: type != pull_request
-    # - name: "Segfault on filtered vector search (race with hash bucket compaction)"
-    #   script: ./segfault_filtered_vector_search.sh
-    #   if: type != pull_request
+    - name: "Import during constant kills/crashes"
+      script: ./import_while_crashing.sh
+      if: type != pull_request
+    - name: "Heavy object store imports while crashing"
+      script: ./import_while_crashing_no_vector.sh
+      if: type != pull_request
+    - name: "Segfault on filtered vector search (race with hash bucket compaction)"
+      script: ./segfault_filtered_vector_search.sh
+      if: type != pull_request
     - name: "Backup & Restore CRUD"
       script: ./backup_and_restore_crud.sh
       if: type != pull_request
@@ -29,21 +29,21 @@ jobs:
     - name: "Backup & Restore version compatibility"
       script: ./backup_and_restore_version_compatibility.sh
       if: type != pull_request
-    # - name: "Compare Recall after import to after restart"
-    #   script: ./compare_recall_after_restart.sh
-    #   if: type != pull_request
-    # - name: "Concurrent inverted index read/write"
-    #   script: ./concurrent_inverted_index_read_write.sh
-    #   if: type != pull_request
-    # - name: "Consecutive create and update operations"
-    #   script: ./consecutive_create_and_update_operations.sh
-    #   if: type != pull_request
-    # - name: "Batch insert mismatch"
-    #   script: ./batch_insert_mismatch.sh
-    #   if: type != pull_request
-    # - name: "REST PATCH requests stop working after restart"
-    #   script: ./rest_patch_stops_working_after_restart.sh
-    #   if: type != pull_request
+    - name: "Compare Recall after import to after restart"
+      script: ./compare_recall_after_restart.sh
+      if: type != pull_request
+    - name: "Concurrent inverted index read/write"
+      script: ./concurrent_inverted_index_read_write.sh
+      if: type != pull_request
+    - name: "Consecutive create and update operations"
+      script: ./consecutive_create_and_update_operations.sh
+      if: type != pull_request
+    - name: "Batch insert mismatch"
+      script: ./batch_insert_mismatch.sh
+      if: type != pull_request
+    - name: "REST PATCH requests stop working after restart"
+      script: ./rest_patch_stops_working_after_restart.sh
+      if: type != pull_request
     # Commented only because this chaos pipeline was able to interrupt save operation
     # just in the middle of it being performed and since Weaviate doesn't have a transaction
     # mechanism implemented then this was causing an error which is a different error then
@@ -52,9 +52,9 @@ jobs:
     # - name: "Compare REST and GraphQL while crashing"
     #   script: ./compare_rest_graphql_while_crashing.sh
     #   if: type != pull_request
-    # - name: "Delete and recreate class with frequent updates"
-    #   script: ./delete_and_recreate_class.sh
-    #   if: type != pull_request
+    - name: "Delete and recreate class with frequent updates"
+      script: ./delete_and_recreate_class.sh
+      if: type != pull_request
 
 before_script:
   # login to docker at the very beginning, so we don't run into rate-limiting

--- a/apps/backup_and_restore_crud/Dockerfile
+++ b/apps/backup_and_restore_crud/Dockerfile
@@ -5,6 +5,9 @@ WORKDIR /workdir
 ARG backend
 ENV BACKUP_BACKEND_PROVIDER=${backend}
 
+ARG expected_shard_count
+ENV EXPECTED_SHARD_COUNT=${expected_shard_count}
+
 COPY requirements.txt .
 RUN pip3 install -r requirements.txt
 

--- a/apps/backup_and_restore_crud/Dockerfile
+++ b/apps/backup_and_restore_crud/Dockerfile
@@ -2,6 +2,9 @@ FROM python:3.10-slim
 
 WORKDIR /workdir
 
+ARG backend
+ENV BACKUP_BACKEND_PROVIDER=${backend}
+
 COPY requirements.txt .
 RUN pip3 install -r requirements.txt
 

--- a/apps/backup_and_restore_version_compatibility/backup_and_restore_version_compatibility.py
+++ b/apps/backup_and_restore_version_compatibility/backup_and_restore_version_compatibility.py
@@ -98,16 +98,16 @@ def hostname(client: weaviate.Client):
     return host
 
 def backup_url_create(client: weaviate.Client):
-    return f"{hostname(client)}/v1/backups/gcs"
+    return f"{hostname(client)}/v1/backups/s3"
 
 def backup_url_create_status(client: weaviate.Client, backup_name):
-    return f"{hostname(client)}/v1/backups/gcs/{backup_name}"
+    return f"{hostname(client)}/v1/backups/s3/{backup_name}"
 
 def backup_url_restore(client: weaviate.Client, backup_name):
-    return f"{hostname(client)}/v1/backups/gcs/{backup_name}/restore"
+    return f"{hostname(client)}/v1/backups/s3/{backup_name}/restore"
 
 def backup_url_restore_status(client: weaviate.Client, backup_name):
-    return f"{hostname(client)}/v1/backups/gcs/{backup_name}/restore"
+    return f"{hostname(client)}/v1/backups/s3/{backup_name}/restore"
 
 def create_backup(client: weaviate.Client, name):
     create_body = {'id': name }

--- a/apps/weaviate/docker-compose-backup.yml
+++ b/apps/weaviate/docker-compose-backup.yml
@@ -21,15 +21,16 @@ services:
       AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED: 'true'
       PERSISTENCE_DATA_PATH: '/var/lib/weaviate'
       DEFAULT_VECTORIZER_MODULE: 'none'
-      ENABLE_MODULES: 'backup-gcs'
+      ENABLE_MODULES: 'backup-s3'
       BACKUP_FILESYSTEM_PATH: '/var/lib/backups'
       CLUSTER_HOSTNAME: 'node1' 
       CLUSTER_GOSSIP_BIND_PORT: '7100'
       CLUSTER_DATA_BIND_PORT: '7101'
-      GOOGLE_CLOUD_PROJECT: 'cluster-version-backup-test'
-      STORAGE_EMULATOR_HOST: 'backup-gcs:9090' 
-      BACKUP_GCS_ENDPOINT: 'backup-gcs:9090'
-      BACKUP_GCS_BUCKET: 'weaviate-backups'
+      BACKUP_S3_ENDPOINT: 'backup-s3:9000'
+      BACKUP_S3_BUCKET: 'weaviate-backups'
+      AWS_ACCESS_KEY_ID: 'aws_access_key'
+      AWS_SECRET_KEY: 'aws_secret_key'
+      BACKUP_S3_USE_SSL: 'false'
 
   # Mutually exclusive with weaviate-node-2
   # Used for single-node BRO version compat
@@ -53,13 +54,15 @@ services:
       AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED: 'true'
       PERSISTENCE_DATA_PATH: '/var/lib/weaviate'
       DEFAULT_VECTORIZER_MODULE: 'none'
-      ENABLE_MODULES: 'backup-gcs'
+      ENABLE_MODULES: 'backup-s3'
       BACKUP_FILESYSTEM_PATH: '/var/lib/backups'
       CLUSTER_HOSTNAME: 'node1' 
-      GOOGLE_CLOUD_PROJECT: 'cluster-version-backup-test'
-      STORAGE_EMULATOR_HOST: 'backup-gcs:9090' 
-      BACKUP_GCS_ENDPOINT: 'backup-gcs:9090'
-      BACKUP_GCS_BUCKET: 'weaviate-backups'
+      BACKUP_S3_ENDPOINT: 'backup-s3:9000'
+      BACKUP_S3_BUCKET: 'weaviate-backups'
+      AWS_ACCESS_KEY_ID: 'aws_access_key'
+      AWS_SECRET_KEY: 'aws_secret_key'
+      BACKUP_S3_USE_SSL: 'false'
+
 
   # Mutually exclusive with weaviate-backup-node
   # Used for cluster backup scenarios
@@ -83,30 +86,49 @@ services:
       AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED: 'true'
       PERSISTENCE_DATA_PATH: '/var/lib/weaviate'
       DEFAULT_VECTORIZER_MODULE: 'none'
-      ENABLE_MODULES: 'backup-gcs'
+      ENABLE_MODULES: 'backup-s3'
       BACKUP_FILESYSTEM_PATH: '/var/lib/backups'
       CLUSTER_HOSTNAME: 'node2' 
       CLUSTER_GOSSIP_BIND_PORT: '7102'
       CLUSTER_DATA_BIND_PORT: '7103'
       CLUSTER_JOIN: 'weaviate-node-1:7100'
-      GOOGLE_CLOUD_PROJECT: 'cluster-version-backup-test'
-      STORAGE_EMULATOR_HOST: 'backup-gcs:9090' 
-      BACKUP_GCS_ENDPOINT: 'backup-gcs:9090'
-      BACKUP_GCS_BUCKET: 'weaviate-backups'
-    volumes:
-    - ./data-node-2:/var/lib/weaviate
+      BACKUP_S3_ENDPOINT: 'backup-s3:9000'
+      BACKUP_S3_BUCKET: 'weaviate-backups'
+      AWS_ACCESS_KEY_ID: 'aws_access_key'
+      AWS_SECRET_KEY: 'aws_secret_key'
+      BACKUP_S3_USE_SSL: 'false'
 
-  backup-gcs:
-    image: oittaa/gcp-storage-emulator
-    command:
-    - 'start'
-    - '--host'
-    - '0.0.0.0'
-    - '--port'
-    - '9090'
-    - '--default-bucket'
-    - 'weaviate-backups'
-    - '--in-memory'
+  backup-s3:
+    image: minio/minio
     ports:
-    - '9090:9090'
+      - "9000:9000"
+    volumes:
+      - ./backups-s3:/data
+    environment:
+      MINIO_ROOT_USER: 'aws_access_key'
+      MINIO_ROOT_PASSWORD: 'aws_secret_key'
+    command: server /data
+
+  create-s3-bucket:
+    image: minio/mc
+    depends_on:
+      - backup-s3
+    entrypoint: >
+      /bin/sh -c "
+      /usr/bin/mc alias set chaos http://backup-s3:9000 aws_access_key aws_secret_key;
+      /usr/bin/mc mb chaos/weaviate-backups;
+      /usr/bin/mc policy set public chaos/weaviate-backups;
+      exit 0;
+      "
+
+  remove-s3-bucket:
+    image: minio/mc
+    depends_on:
+      - backup-s3
+    entrypoint: >
+      /bin/sh -c "
+      /usr/bin/mc alias set chaos http://backup-s3:9000 aws_access_key aws_secret_key;
+      /usr/bin/mc rb --force chaos/weaviate-backups;
+      exit 0;
+      "
 ...

--- a/backup_and_restore_multi_node_crud.sh
+++ b/backup_and_restore_multi_node_crud.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+set -e
+
+function wait_weaviate_cluster() {
+  echo "Wait for Weaviate to be ready"
+  local node1_ready=false
+  local node2_ready=false
+  for _ in {1..120}; do
+    if curl -sf -o /dev/null localhost:8080; then
+      echo "Weaviate node1 is ready"
+      node1_ready=true
+    fi
+
+    if curl -sf -o /dev/null localhost:8081; then
+      echo "Weaviate node2 is ready"
+      node2_ready=true
+    fi
+
+    if $node1_ready && $node2_ready; then
+      break
+    fi
+
+    echo "Weaviate cluster is not ready, trying again in 1s"
+    sleep 1
+  done
+}
+
+echo "Building all required containers"
+( cd apps/backup_and_restore_crud/ && docker build -t backup_and_restore_crud --build-arg backend="s3" . )
+
+export WEAVIATE_NODE_1_VERSION=$WEAVIATE_VERSION
+export WEAVIATE_NODE_2_VERSION=$WEAVIATE_VERSION
+
+echo "Starting Weaviate..."
+docker-compose -f apps/weaviate/docker-compose-backup.yml up -d weaviate-node-1 weaviate-node-2 backup-s3
+
+wait_weaviate_cluster
+
+echo "Creating S3 bucket..."
+docker compose -f apps/weaviate/docker-compose-backup.yml up create-s3-bucket
+
+echo "Run multi-node backup and restore CRUD operations"
+docker run --network host -it backup_and_restore_crud python3 backup_and_restore_crud.py
+
+echo "Passed!"

--- a/backup_and_restore_multi_node_crud.sh
+++ b/backup_and_restore_multi_node_crud.sh
@@ -38,7 +38,7 @@ docker-compose -f apps/weaviate/docker-compose-backup.yml up -d weaviate-node-1 
 wait_weaviate_cluster
 
 echo "Creating S3 bucket..."
-docker compose -f apps/weaviate/docker-compose-backup.yml up create-s3-bucket
+docker-compose -f apps/weaviate/docker-compose-backup.yml up create-s3-bucket
 
 echo "Run multi-node backup and restore CRUD operations"
 docker run --network host -it backup_and_restore_crud python3 backup_and_restore_crud.py

--- a/backup_and_restore_multi_node_crud.sh
+++ b/backup_and_restore_multi_node_crud.sh
@@ -27,7 +27,8 @@ function wait_weaviate_cluster() {
 }
 
 echo "Building all required containers"
-( cd apps/backup_and_restore_crud/ && docker build -t backup_and_restore_crud --build-arg backend="s3" . )
+( cd apps/backup_and_restore_crud/ && docker build -t backup_and_restore_crud \
+  --build-arg backend="s3" --build-arg expected_shard_count=2 . )
 
 export WEAVIATE_NODE_1_VERSION=$WEAVIATE_VERSION
 export WEAVIATE_NODE_2_VERSION=$WEAVIATE_VERSION

--- a/backup_and_restore_version_compatibility.sh
+++ b/backup_and_restore_version_compatibility.sh
@@ -56,13 +56,13 @@ for pair in "${!version_pairs[@]}"; do
   wait_weaviate_cluster
 
   echo "Creating S3 bucket..."
-  docker compose -f apps/weaviate/docker-compose-backup.yml up create-s3-bucket
+  docker-compose -f apps/weaviate/docker-compose-backup.yml up create-s3-bucket
 
   echo "Run backup (v${backup_version}) and restore (v${restore_version}) version compatibility operations"
   docker run --rm --network host -it backup_and_restore_version_compatibility python3 backup_and_restore_version_compatibility.py
 
   echo "Removing S3 bucket..."
-  docker compose -f apps/weaviate/docker-compose-backup.yml up remove-s3-bucket
+  docker-compose -f apps/weaviate/docker-compose-backup.yml up remove-s3-bucket
 
   echo "Cleaning up containers for next test..."
   docker-compose -f apps/weaviate/docker-compose-backup.yml down --remove-orphans


### PR DESCRIPTION
Uses the existing `backup_and_restore_crud` app to run the CRUD chaos tests on a multi-node setup. Currently the single node `backup_and_restore_crud` test remains, but we can probably remove it in the future once there is no doubt that multi-node and singe-node backup/restore behaviors are in parity. Under the hood there is not a distinction between single and multi node backups, but "better safe than sorry" for now.

Also, the GCS emulator has been removed in favor of Minio/S3. This is because:
- The GCS emulator is buggy when object counts exceed a trivial amount. It starts returning 404s when the number of backed up objects approaches 1,000. The test introduced in this PR generates 100,000 objects.
- The GCS emulator is neither an official Google image, nor is it maintained by a well known or reliable organization.

Minio does not suffer from these issues, and so is better suited in our pipeline tests. 