### PR TITLE
RQ 1 bit: Run tests for 1.33 release

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -198,8 +198,8 @@ jobs:
         uses: fabriziocacicia/semver-compare-action@v0.1.0
         with:
           first: ${{ needs.real-version-in-tag.outputs.real_version }}
-          second: "1.33.0-dev"  # TODO: change to 1.33.0 when the version is released
-          operator: ">="          
+          second: "1.33.0"
+          operator: ">="
   filter-memory-leak:
     name: Filter (cache) memory leak when querying while importing
     if: ${{ github.event.inputs.test_to_run == 'filter-memory-leak' || github.event.inputs.test_to_run == '' }}


### PR DESCRIPTION
Run the tests if 1.33 version is detected, not based on -dev.

Also, reduce the recall expected with RQ 1 bit in one specific dataset.

It completes: https://github.com/weaviate/weaviate-qa/issues/7