### PR TITLE
fix(backup-restore): check for exit code instead of word failed

### DIFF
--- a/backup_and_restore_version_compatibility.sh
+++ b/backup_and_restore_version_compatibility.sh
@@ -41,9 +41,11 @@ cd apps/backup_and_restore_version_compatibility/ && docker build -f Dockerfile_
     -t generate_version_pairs --build-arg weaviate_version=${WEAVIATE_VERSION} .
 cd -
 
-pair_string=$(docker run --rm generate_version_pairs)
-if [[ $pair_string =~ 'failed' ]]; then
-  echo "ERROR: ${pair_string}"
+pair_string=$(docker run --rm generate_version_pairs 2>&1)
+exit_code=$?
+if [ $exit_code -ne 0 ]; then
+  echo "ERROR: Failed to generate version pairs (exit code: $exit_code)"
+  echo "Output: ${pair_string}"
   exit 1
 fi
 


### PR DESCRIPTION
test is failing in case the image tag  has word `failed`, with this change it will depend on the docker run exit code instead of image tag 

before : https://github.com/weaviate/weaviate-chaos-engineering/actions/runs/17586658295/job/50122884508
after : https://github.com/weaviate/weaviate-chaos-engineering/actions/runs/17643440389/job/50135591224