### PR TITLE
fix(install): harden Docker install on Ubuntu 22.04 EC2

### DIFF
--- a/install_docker_ubuntu.sh
+++ b/install_docker_ubuntu.sh
@@ -1,9 +1,16 @@
 set -e
 
+export DEBIAN_FRONTEND=noninteractive
+
 sudo apt-get remove docker docker-engine docker.io containerd runc || true
 
 # Update the package list
-sudo apt-get update
+sudo apt-get update -o Acquire::ForceIPv4=true || {
+  # Retry with a clean apt state in case of transient mirror/proxy issues
+  sudo rm -rf /var/lib/apt/lists/*
+  sudo apt-get clean
+  sudo apt-get update -o Acquire::ForceIPv4=true
+}
 
 # Install required packages
 sudo apt-get install -y \
@@ -20,5 +27,9 @@ echo \
   "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu \
   $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
 
-sudo apt-get update
+sudo apt-get update -o Acquire::ForceIPv4=true || {
+  sudo rm -rf /var/lib/apt/lists/*
+  sudo apt-get clean
+  sudo apt-get update -o Acquire::ForceIPv4=true
+}
 sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin


### PR DESCRIPTION
- Force IPv4 on apt-get update to avoid IPv6/mirror flakes
- Clean /var/lib/apt/lists and retry update on failure (InRelease split/signature)
- Set DEBIAN_FRONTEND=noninteractive to prevent prompts
- Prevents CI flakes: “repo is not signed” and “Unable to locate package docker”