### PR TITLE
Fix race between mc bucket creation and MinIO startup

### DIFF
--- a/apps/replicated_import_with_backup/docker-compose.yml
+++ b/apps/replicated_import_with_backup/docker-compose.yml
@@ -64,11 +64,16 @@ services:
       - backup-s3
     entrypoint: >
       /bin/sh -c "
-      /usr/bin/mc alias set chaos http://backup-s3:9000 aws_access_key aws_secret_key;
+      set -e;
+      i=0;
+      until /usr/bin/mc alias set chaos http://backup-s3:9000 aws_access_key aws_secret_key; do
+        i=$$((i+1));
+        if [ $$i -ge 60 ]; then echo 'ERROR: MinIO not ready after 60s'; exit 1; fi;
+        echo 'Waiting for MinIO to be ready...'; sleep 1;
+      done;
       /usr/bin/mc mb chaos/weaviate-backups;
       /usr/bin/mc rm --force --recursive --quiet chaos/weaviate-backups;
       /usr/bin/mc policy set public chaos/weaviate-backups;
-      exit 0;
       "
 
   remove-s3-bucket:
@@ -78,9 +83,14 @@ services:
       - backup-s3
     entrypoint: >
       /bin/sh -c "
-      /usr/bin/mc alias set chaos http://backup-s3:9000 aws_access_key aws_secret_key;
+      set -e;
+      i=0;
+      until /usr/bin/mc alias set chaos http://backup-s3:9000 aws_access_key aws_secret_key; do
+        i=$$((i+1));
+        if [ $$i -ge 60 ]; then echo 'ERROR: MinIO not ready after 60s'; exit 1; fi;
+        echo 'Waiting for MinIO to be ready...'; sleep 1;
+      done;
       /usr/bin/mc rb --force chaos/weaviate-backups;
-      exit 0;
       "
 
   importer-schema-node-1:

--- a/apps/replicated_import_with_backup/docker-compose.yml
+++ b/apps/replicated_import_with_backup/docker-compose.yml
@@ -71,7 +71,7 @@ services:
         if [ $$i -ge 60 ]; then echo 'ERROR: MinIO not ready after 60s'; exit 1; fi;
         echo 'Waiting for MinIO to be ready...'; sleep 1;
       done;
-      /usr/bin/mc mb chaos/weaviate-backups;
+      /usr/bin/mc mb --ignore-existing chaos/weaviate-backups;
       /usr/bin/mc rm --force --recursive --quiet chaos/weaviate-backups;
       /usr/bin/mc policy set public chaos/weaviate-backups;
       "

--- a/apps/weaviate/docker-compose-backup-3nodes-renamed.yml
+++ b/apps/weaviate/docker-compose-backup-3nodes-renamed.yml
@@ -165,7 +165,7 @@ services:
         if [ $$i -ge 60 ]; then echo 'ERROR: MinIO not ready after 60s'; exit 1; fi;
         echo 'Waiting for MinIO to be ready...'; sleep 1;
       done;
-      /usr/bin/mc mb chaos/weaviate-backups;
+      /usr/bin/mc mb --ignore-existing chaos/weaviate-backups;
       /usr/bin/mc policy set public chaos/weaviate-backups;
       "
     networks:

--- a/apps/weaviate/docker-compose-backup-3nodes-renamed.yml
+++ b/apps/weaviate/docker-compose-backup-3nodes-renamed.yml
@@ -158,10 +158,15 @@ services:
       - backup-s3
     entrypoint: >
       /bin/sh -c "
-      /usr/bin/mc alias set chaos http://backup-s3:9000 aws_access_key aws_secret_key;
+      set -e;
+      i=0;
+      until /usr/bin/mc alias set chaos http://backup-s3:9000 aws_access_key aws_secret_key; do
+        i=$$((i+1));
+        if [ $$i -ge 60 ]; then echo 'ERROR: MinIO not ready after 60s'; exit 1; fi;
+        echo 'Waiting for MinIO to be ready...'; sleep 1;
+      done;
       /usr/bin/mc mb chaos/weaviate-backups;
       /usr/bin/mc policy set public chaos/weaviate-backups;
-      exit 0;
       "
     networks:
       weaviate_backup_3nodes_renamed:
@@ -173,9 +178,14 @@ services:
       - backup-s3
     entrypoint: >
       /bin/sh -c "
-      /usr/bin/mc alias set chaos http://backup-s3:9000 aws_access_key aws_secret_key;
+      set -e;
+      i=0;
+      until /usr/bin/mc alias set chaos http://backup-s3:9000 aws_access_key aws_secret_key; do
+        i=$$((i+1));
+        if [ $$i -ge 60 ]; then echo 'ERROR: MinIO not ready after 60s'; exit 1; fi;
+        echo 'Waiting for MinIO to be ready...'; sleep 1;
+      done;
       /usr/bin/mc rb --force chaos/weaviate-backups;
-      exit 0;
       "
     networks:
       weaviate_backup_3nodes_renamed:

--- a/apps/weaviate/docker-compose-backup-3nodes.yml
+++ b/apps/weaviate/docker-compose-backup-3nodes.yml
@@ -162,7 +162,7 @@ services:
         if [ $$i -ge 60 ]; then echo 'ERROR: MinIO not ready after 60s'; exit 1; fi;
         echo 'Waiting for MinIO to be ready...'; sleep 1;
       done;
-      /usr/bin/mc mb chaos/weaviate-backups;
+      /usr/bin/mc mb --ignore-existing chaos/weaviate-backups;
       /usr/bin/mc policy set public chaos/weaviate-backups;
       "
     networks:

--- a/apps/weaviate/docker-compose-backup-3nodes.yml
+++ b/apps/weaviate/docker-compose-backup-3nodes.yml
@@ -155,10 +155,15 @@ services:
       - backup-s3
     entrypoint: >
       /bin/sh -c "
-      /usr/bin/mc alias set chaos http://backup-s3:9000 aws_access_key aws_secret_key;
+      set -e;
+      i=0;
+      until /usr/bin/mc alias set chaos http://backup-s3:9000 aws_access_key aws_secret_key; do
+        i=$$((i+1));
+        if [ $$i -ge 60 ]; then echo 'ERROR: MinIO not ready after 60s'; exit 1; fi;
+        echo 'Waiting for MinIO to be ready...'; sleep 1;
+      done;
       /usr/bin/mc mb chaos/weaviate-backups;
       /usr/bin/mc policy set public chaos/weaviate-backups;
-      exit 0;
       "
     networks:
       weaviate_backup_3nodes:
@@ -170,9 +175,14 @@ services:
       - backup-s3
     entrypoint: >
       /bin/sh -c "
-      /usr/bin/mc alias set chaos http://backup-s3:9000 aws_access_key aws_secret_key;
+      set -e;
+      i=0;
+      until /usr/bin/mc alias set chaos http://backup-s3:9000 aws_access_key aws_secret_key; do
+        i=$$((i+1));
+        if [ $$i -ge 60 ]; then echo 'ERROR: MinIO not ready after 60s'; exit 1; fi;
+        echo 'Waiting for MinIO to be ready...'; sleep 1;
+      done;
       /usr/bin/mc rb --force chaos/weaviate-backups;
-      exit 0;
       "
     networks:
       weaviate_backup_3nodes:

--- a/apps/weaviate/docker-compose-backup.yml
+++ b/apps/weaviate/docker-compose-backup.yml
@@ -144,10 +144,15 @@ services:
       - backup-s3
     entrypoint: >
       /bin/sh -c "
-      /usr/bin/mc alias set chaos http://backup-s3:9000 aws_access_key aws_secret_key;
+      set -e;
+      i=0;
+      until /usr/bin/mc alias set chaos http://backup-s3:9000 aws_access_key aws_secret_key; do
+        i=$$((i+1));
+        if [ $$i -ge 60 ]; then echo 'ERROR: MinIO not ready after 60s'; exit 1; fi;
+        echo 'Waiting for MinIO to be ready...'; sleep 1;
+      done;
       /usr/bin/mc mb chaos/weaviate-backups;
       /usr/bin/mc policy set public chaos/weaviate-backups;
-      exit 0;
       "
     networks:
       weaviate_backup:
@@ -159,9 +164,14 @@ services:
       - backup-s3
     entrypoint: >
       /bin/sh -c "
-      /usr/bin/mc alias set chaos http://backup-s3:9000 aws_access_key aws_secret_key;
+      set -e;
+      i=0;
+      until /usr/bin/mc alias set chaos http://backup-s3:9000 aws_access_key aws_secret_key; do
+        i=$$((i+1));
+        if [ $$i -ge 60 ]; then echo 'ERROR: MinIO not ready after 60s'; exit 1; fi;
+        echo 'Waiting for MinIO to be ready...'; sleep 1;
+      done;
       /usr/bin/mc rb --force chaos/weaviate-backups;
-      exit 0;
       "
     networks:
       weaviate_backup:

--- a/apps/weaviate/docker-compose-backup.yml
+++ b/apps/weaviate/docker-compose-backup.yml
@@ -151,7 +151,7 @@ services:
         if [ $$i -ge 60 ]; then echo 'ERROR: MinIO not ready after 60s'; exit 1; fi;
         echo 'Waiting for MinIO to be ready...'; sleep 1;
       done;
-      /usr/bin/mc mb chaos/weaviate-backups;
+      /usr/bin/mc mb --ignore-existing chaos/weaviate-backups;
       /usr/bin/mc policy set public chaos/weaviate-backups;
       "
     networks:


### PR DESCRIPTION
## Summary

- The backup-s3 test flow races MinIO startup: the `create-s3-bucket` / `remove-s3-bucket` one-shot containers were running `mc alias set` the moment MinIO's container hit *Started*, without waiting for the MinIO server to actually accept connections on :9000. Under CI load this occasionally lost the race, `mc` failed to connect, and the original entrypoint swallowed the error via `;` chaining + unconditional `exit 0`. Weaviate's subsequent backup access-check `PutObject` then got `NoSuchBucket` → HTTP 422.
- Fix the entrypoints for `create-s3-bucket` and `remove-s3-bucket` in all four compose files that define them: retry `mc alias set` until MinIO accepts a connection (bounded to 60 attempts at 1s apart), and use `set -e` so any later `mc` failure surfaces instead of being masked.
- No shell-script changes were needed — the fix is isolated to the mc entrypoints in the compose files, so every caller (`backup_and_restore_version_compatibility.sh`, `backup_and_restore_multi_node_crud.sh`, `backup_and_restore_multi_node_out_of_sync.sh`, `backup_and_restore_node_mapping.sh`, `replication_importing_with_backup.sh`) benefits automatically.

## Context

This was observed in the `backup_and_restore_version_compatibility` pipeline on iteration 14 of a 30-version sweep: https://github.com/weaviate/weaviate-chaos-engineering/actions/runs/24540725312/job/71745720199

```
Backup Create returned status code 422 with body:
{'error': [{'message': 'init uploader: failed to access-check s3 backup module:
 put object: weaviate-backups:backup_1776385396/access-check:
 The specified bucket does not exist'}]}
```

Job-log timing shows the race clearly:

- `00:23:06.411` — `backup-s3 Started` (container up, MinIO still initializing)
- `00:23:14.612` — `Weaviate node1 is ready` (script proceeds — never probes MinIO)
- `00:23:15.199` — `mc: connection refused` on 172.23.0.10:9000 (MinIO still not listening)
- `00:23:15.223` — `Bucket created successfully` (30 ms later; MinIO just barely came up, bucket not durable yet)
- `00:23:15.354` — `create-s3-bucket exited with code 0` (masked by `exit 0`)
- `00:23:16.564` — Weaviate access-check PUT → `NoSuchBucket` → 422

In the immediately preceding iteration the log shows `Added 'chaos' successfully.` and a `backup-s3 Running` event before `create-s3-bucket` started. In the failing iteration both are absent, confirming MinIO was still starting when `mc` raced it.

## Test plan

- [x] `docker compose -f apps/weaviate/docker-compose-backup.yml config` — all four compose files parse cleanly.
- [x] `sh -n` on the rendered entrypoint — valid.
- [x] Happy path: `up -d backup-s3` then `up create-s3-bucket` — bucket created, exit 0.
- [x] Happy path: `up remove-s3-bucket` — bucket removed, exit 0.
- [x] Failure path: ran the retry loop against a non-existent host with a 3-attempt cap — observed three `Waiting for MinIO to be ready...` messages followed by `ERROR: MinIO not ready after 3s` and a non-zero exit (confirms `set -e` + bounded loop surface failures).
- [ ] Re-run the `backup_and_restore_version_compatibility` Test matrix job that previously flaked to confirm it no longer reproduces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)