### PR TITLE
fix(analyze-segments): skip segments removed by compaction during analysis

### DIFF
--- a/apps/analyze-segments/main.go
+++ b/apps/analyze-segments/main.go
@@ -73,6 +73,17 @@ func main() {
 	}
 }
 
+// compactedSegmentRegex matches Weaviate's final (non-transient) segment filenames
+// that could carry a missing segment's ID as evidence of compaction:
+//   - segment-{id}.db
+//   - segment-{id}.l{level}.s{strategy}.db
+//   - segment-{leftID}_{rightID}.db
+//   - segment-{leftID}_{rightID}.l{level}.s{strategy}.db
+//
+// Transient files (e.g. segment-{id}.db.tmp, .wal) are intentionally excluded so
+// they cannot be mistaken for a successful compaction output.
+var compactedSegmentRegex = regexp.MustCompile(`^segment-[0-9]+(_[0-9]+)?(\.l[0-9]+\.s[0-9]+)?\.db$`)
+
 // wasCompacted confirms that a segment that could not be opened was removed by an LSM
 // compaction rather than by an unexpected cause. Two conditions must hold:
 //
@@ -84,8 +95,9 @@ func main() {
 //       segment-{leftID}_{rightID}[.l{level}.s{strategy}].db
 //     A cleanup pass may also produce segment-{id}.l{level}.s{strategy}.db for the
 //     same base ID. In both cases the missing segment's ID appears as a name
-//     component. Finding such a file confirms the data is present in a newer segment,
-//     not silently lost.
+//     component. Candidates must match compactedSegmentRegex so transient files
+//     (e.g. *.db.tmp) cannot trigger a false positive. Finding such a file confirms
+//     the data is present in a newer segment, not silently lost.
 func wasCompacted(dir, missingName string) bool {
 	// (1) Confirm the file is actually gone.
 	if _, err := os.Stat(filepath.Join(dir, missingName)); !errors.Is(err, os.ErrNotExist) {
@@ -112,12 +124,12 @@ func wasCompacted(dir, missingName string) bool {
 	rightSuffix := "_" + id + "."
 	for _, e := range entries {
 		n := e.Name()
-		if n == missingName {
+		if n == missingName || !compactedSegmentRegex.MatchString(n) {
 			continue
 		}
 		if strings.HasPrefix(n, leftOrCleanup+"_") ||
 			strings.HasPrefix(n, leftOrCleanup+".") ||
-			(strings.HasPrefix(n, "segment-") && strings.Contains(n, rightSuffix)) {
+			strings.Contains(n, rightSuffix) {
 			return true
 		}
 	}

--- a/apps/analyze-segments/main.go
+++ b/apps/analyze-segments/main.go
@@ -100,11 +100,12 @@ func wasCompacted(dir, missingName string) bool {
 	}
 
 	// (2) Look for a file that carries this segment's ID as:
-	//   - left half of a merge:  segment-{id}_...
+	//   - left half of a merge:    segment-{id}_...
 	//   - same-ID cleanup rewrite: segment-{id}....  (different suffix, e.g. .l0.s5.db)
-	//   - right half of a merge: ..._  {id}.  (id followed by "." or end of name base)
+	//   - right half of a merge:   segment-{otherID}_{id}.  (id followed by ".")
 	entries, err := os.ReadDir(dir)
 	if err != nil {
+		log.Printf("wasCompacted: readdir %s: %v\n", dir, err)
 		return false
 	}
 	leftOrCleanup := "segment-" + id
@@ -116,7 +117,7 @@ func wasCompacted(dir, missingName string) bool {
 		}
 		if strings.HasPrefix(n, leftOrCleanup+"_") ||
 			strings.HasPrefix(n, leftOrCleanup+".") ||
-			strings.Contains(n, rightSuffix) {
+			(strings.HasPrefix(n, "segment-") && strings.Contains(n, rightSuffix)) {
 			return true
 		}
 	}

--- a/apps/analyze-segments/main.go
+++ b/apps/analyze-segments/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/binary"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -9,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strings"
 )
 
 func main() {
@@ -44,6 +46,16 @@ func main() {
 			func() {
 				f, err := os.OpenFile(filepath.Join(segmentsPath, info.Name()), os.O_RDONLY, os.ModePerm)
 				if err != nil {
+					// A segment can disappear between os.ReadDir and os.OpenFile when an LSM
+					// compaction completes in that window. Weaviate writes the merged result
+					// (segment-{leftID}_{rightID}.db) before deleting the inputs, so the data
+					// is never lost. We confirm this specific TOCTOU case by checking that
+					// (a) the file is truly gone and (b) a derived segment carrying this
+					// segment's ID exists. Any other open error is still fatal.
+					if errors.Is(err, os.ErrNotExist) && wasCompacted(segmentsPath, info.Name()) {
+						log.Printf("skipping %s: removed by compaction during analysis\n", info.Name())
+						return
+					}
 					log.Fatal(err)
 				}
 				defer f.Close()
@@ -59,4 +71,54 @@ func main() {
 			}()
 		}
 	}
+}
+
+// wasCompacted confirms that a segment that could not be opened was removed by an LSM
+// compaction rather than by an unexpected cause. Two conditions must hold:
+//
+//  1. The file is truly absent (os.ErrNotExist on re-stat), ruling out a transient
+//     open error.
+//
+//  2. A segment derived from this one now exists in the same directory. Weaviate's
+//     compactor merges two adjacent segments and names the output:
+//       segment-{leftID}_{rightID}[.l{level}.s{strategy}].db
+//     A cleanup pass may also produce segment-{id}.l{level}.s{strategy}.db for the
+//     same base ID. In both cases the missing segment's ID appears as a name
+//     component. Finding such a file confirms the data is present in a newer segment,
+//     not silently lost.
+func wasCompacted(dir, missingName string) bool {
+	// (1) Confirm the file is actually gone.
+	if _, err := os.Stat(filepath.Join(dir, missingName)); !errors.Is(err, os.ErrNotExist) {
+		return false
+	}
+
+	// Extract the segment ID: everything between "segment-" and the first ".".
+	// e.g. "segment-1771258130098421000.db" → "1771258130098421000"
+	id, _, _ := strings.Cut(strings.TrimPrefix(missingName, "segment-"), ".")
+	if id == "" {
+		return false
+	}
+
+	// (2) Look for a file that carries this segment's ID as:
+	//   - left half of a merge:  segment-{id}_...
+	//   - same-ID cleanup rewrite: segment-{id}....  (different suffix, e.g. .l0.s5.db)
+	//   - right half of a merge: ..._  {id}.  (id followed by "." or end of name base)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return false
+	}
+	leftOrCleanup := "segment-" + id
+	rightSuffix := "_" + id + "."
+	for _, e := range entries {
+		n := e.Name()
+		if n == missingName {
+			continue
+		}
+		if strings.HasPrefix(n, leftOrCleanup+"_") ||
+			strings.HasPrefix(n, leftOrCleanup+".") ||
+			strings.Contains(n, rightSuffix) {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
## Summary

- `analyze-segments` crashes with `log.Fatal` when `os.OpenFile` returns `ENOENT` on a segment that was listed by `os.ReadDir` but then deleted by a concurrent LSM compaction (TOCTOU race).
- This caused the `compaction_optimization.sh` chaos job to fail even when the Weaviate server was healthy.
- Add `wasCompacted()` to confirm the specific case before fataling: the file must be truly absent (re-stat) **and** a derived segment carrying the missing segment's ID must exist in the same directory, matching Weaviate's `segment-{leftID}_{rightID}[.l{level}.s{strategy}].db` naming convention. Any other open error is still fatal.

## Test plan

- [x] Run `compaction_optimization.sh` against a Weaviate instance under active compaction load; verify the analyzer no longer crashes with `ENOENT` and instead logs `skipping <name>: removed by compaction during analysis`
- [x] Verify that a genuine missing-segment error (e.g., manual deletion without a corresponding merged file) still calls `log.Fatal`

🤖 Generated with [Claude Code](https://claude.com/claude-code)