### PR TITLE
fix: wait for async vector indexing before sanity checks in upgrade-journey

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -2196,7 +2196,7 @@ jobs:
       - name: Weaviate ${{env.WEAVIATE_INITIAL_VERSION}} - import data
         run: |
           cd apps/upgrade-journey-raft
-          python3 run.py --api-key ${{ env.WEAVIATE_API_KEY_CUSTOM}}
+          python3 run.py --api-key ${{ env.WEAVIATE_API_KEY_CUSTOM}} --admin-api-key ${{ env.WEAVIATE_API_KEY }}
       - name: Weaviate ${{env.WEAVIATE_INITIAL_VERSION}} - check roles
         run: |
           cd apps/rbac-upgrade-journey
@@ -2247,7 +2247,7 @@ jobs:
       - name: Weaviate ${{ env.WEAVIATE_VERSION}} - add additional data and check all (old and new) data
         run: |
           cd apps/upgrade-journey-raft
-          python3 additional_run.py --api-key ${{ env.WEAVIATE_API_KEY_CUSTOM}}
+          python3 additional_run.py --api-key ${{ env.WEAVIATE_API_KEY_CUSTOM}} --admin-api-key ${{ env.WEAVIATE_API_KEY }}
           python3 additional_checks.py --api-key ${{ env.WEAVIATE_API_KEY_CUSTOM}}
       - name: Weaviate ${{ env.WEAVIATE_VERSION}} - add additional roles and check all (old and new) roles
         run: |

--- a/apps/upgrade-journey-raft/additional_run.py
+++ b/apps/upgrade-journey-raft/additional_run.py
@@ -1,18 +1,33 @@
 import argparse
+import contextlib
 from loguru import logger
 import weaviate
 import multitenancy
 from show_logs import show_logs
 
 
-def create(api_key=None):
+def create(api_key=None, admin_api_key=None):
     try:
-        logger.info("Connect to Weaviate")
-        with weaviate.connect_to_local(
-            auth_credentials=weaviate.auth.AuthApiKey(api_key=api_key) if api_key else None
-        ) as client:
+        with contextlib.ExitStack() as stack:
+            logger.info("Connect to Weaviate")
+            client = stack.enter_context(
+                weaviate.connect_to_local(
+                    auth_credentials=weaviate.auth.AuthApiKey(api_key=api_key) if api_key else None
+                )
+            )
+            # See run.py: wait_for_vector_indexing() needs read_tenants on the target
+            # collection, which the workload user lacks under RBAC. Open a separate admin
+            # connection for the readiness wait when an admin key is supplied.
+            if admin_api_key and admin_api_key != api_key:
+                admin_client = stack.enter_context(
+                    weaviate.connect_to_local(
+                        auth_credentials=weaviate.auth.AuthApiKey(api_key=admin_api_key)
+                    )
+                )
+            else:
+                admin_client = client
             logger.info("Add additional Multitenancy data")
-            multitenancy.create_additional(client)
+            multitenancy.create_additional(client, admin_client)
             multitenancy.sanity_checks_additional(client)
         logger.success("Success")
     except:
@@ -23,5 +38,10 @@ def create(api_key=None):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--api-key", help="API key for authentication", default=None)
+    parser.add_argument(
+        "--admin-api-key",
+        help="Admin API key used only for privileged readiness waits under RBAC",
+        default=None,
+    )
     args = parser.parse_args()
-    create(args.api_key)
+    create(args.api_key, args.admin_api_key)

--- a/apps/upgrade-journey-raft/books.py
+++ b/apps/upgrade-journey-raft/books.py
@@ -9,9 +9,9 @@ from weaviate.collections.classes.config import ConsistencyLevel
 from graphql_aggregate import graphql_grpc_aggregate
 
 
-def create(client: weaviate.WeaviateClient):
+def create(client: weaviate.WeaviateClient, admin_client: weaviate.WeaviateClient):
     _create_schema(client)
-    _import(client)
+    _import(client, admin_client)
 
 
 def _create_schema(client: weaviate.WeaviateClient):
@@ -19,9 +19,9 @@ def _create_schema(client: weaviate.WeaviateClient):
     _create_authors_schema(client)
 
 
-def _import(client: weaviate.WeaviateClient):
-    _import_books(client)
-    _import_authors(client)
+def _import(client: weaviate.WeaviateClient, admin_client: weaviate.WeaviateClient):
+    _import_books(client, admin_client)
+    _import_authors(client, admin_client)
 
 
 def sanity_checks(client: weaviate.WeaviateClient):
@@ -88,7 +88,7 @@ def _create_authors_schema(client: weaviate.WeaviateClient):
     assert authors.name == "Authors"
 
 
-def _import_books(client: weaviate.WeaviateClient):
+def _import_books(client: weaviate.WeaviateClient, admin_client: weaviate.WeaviateClient):
     books_json = "data/books/books.json"
     with open(books_json) as f:
         books = json.load(f)
@@ -98,9 +98,15 @@ def _import_books(client: weaviate.WeaviateClient):
             for book in books:
                 batch.add_object(properties=book, uuid=book["uuid"])
             batch.flush()
+        logger.info("waiting for Books vector indexing to finish")
+        # wait_for_vector_indexing() calls GET /schema/{class}/shards, which Weaviate
+        # authorizes via read_tenants. Under RBAC, the workload user lacks that on Books*,
+        # so the runner passes a separate admin client for the readiness wait.
+        admin_client.collections.get("Books").batch.wait_for_vector_indexing()
+        logger.info("Books vector indexing finished")
 
 
-def _import_authors(client: weaviate.WeaviateClient):
+def _import_authors(client: weaviate.WeaviateClient, admin_client: weaviate.WeaviateClient):
     books_json = "data/books/books.json"
     authors_books = dict()
     authors_genres = dict()
@@ -133,6 +139,10 @@ def _import_authors(client: weaviate.WeaviateClient):
                 uuid = batch.add_object(properties=properties, uuid=generate_uuid5(properties))
                 author_uuids[author] = uuid
             batch.flush()
+        logger.info("waiting for Authors vector indexing to finish")
+        # See note in _import_books: shards-readiness requires read_tenants under RBAC.
+        admin_client.collections.get("Authors").batch.wait_for_vector_indexing()
+        logger.info("Authors vector indexing finished")
 
         refs_list = []
         for author in author_uuids:

--- a/apps/upgrade-journey-raft/multitenancy.py
+++ b/apps/upgrade-journey-raft/multitenancy.py
@@ -12,11 +12,11 @@ number_of_tenants = 300
 additional_number_of_tenants = 100
 
 
-def create(client: weaviate.WeaviateClient):
+def create(client: weaviate.WeaviateClient, admin_client: weaviate.WeaviateClient):
     for i in range(number_of_tenants):
         _create_multitenancy_schema(client, i)
     for i in range(number_of_tenants):
-        _import_books(client, i)
+        _import_books(client, admin_client, i)
 
 
 def check_collections_existence(client: weaviate.WeaviateClient):
@@ -30,12 +30,12 @@ def sanity_checks(client: weaviate.WeaviateClient):
     logger.info("[sanity_checks] going further")
 
 
-def create_additional(client: weaviate.WeaviateClient):
+def create_additional(client: weaviate.WeaviateClient, admin_client: weaviate.WeaviateClient):
     suffix = "Additional"
     for i in range(additional_number_of_tenants):
         _create_multitenancy_schema(client, i, suffix=suffix)
     for i in range(additional_number_of_tenants):
-        _import_books(client, i, suffix=suffix)
+        _import_books(client, admin_client, i, suffix=suffix)
 
 
 def check_additional_collections_existence(client: weaviate.WeaviateClient):
@@ -88,7 +88,12 @@ def _create_multitenancy_schema(client: weaviate.WeaviateClient, i: int, suffix:
     collection.tenants.create(tenants=[Tenant(name=tenant)])
 
 
-def _import_books(client: weaviate.WeaviateClient, i: int, suffix: str = ""):
+def _import_books(
+    client: weaviate.WeaviateClient,
+    admin_client: weaviate.WeaviateClient,
+    i: int,
+    suffix: str = "",
+):
     class_name = _get_class_name(i, suffix)
     tenant = _get_tenant_name(i, suffix)
     books_json = "data/books/books.json"
@@ -108,6 +113,13 @@ def _import_books(client: weaviate.WeaviateClient, i: int, suffix: str = ""):
                     uuid=book["uuid"],
                 )
             batch.flush()
+        logger.debug("waiting for {} vector indexing to finish", class_name)
+        # See note in books.py: shards-readiness requires read_tenants under RBAC; use admin
+        # creds for the readiness wait while the workload itself stays on the test user.
+        admin_client.collections.get(class_name).with_tenant(
+            tenant
+        ).batch.wait_for_vector_indexing()
+        logger.debug("{} vector indexing finished", class_name)
 
 
 def _wait_for_collections_to_exist(client: weaviate.WeaviateClient, suffix: str = "") -> bool:

--- a/apps/upgrade-journey-raft/run.py
+++ b/apps/upgrade-journey-raft/run.py
@@ -1,23 +1,39 @@
 import argparse
+import contextlib
 from loguru import logger
 import weaviate
 import books, multitenancy
 from show_logs import show_logs
 
 
-def create(api_key=None):
+def create(api_key=None, admin_api_key=None):
     try:
-        logger.info("Connect to Weaviate")
-        with weaviate.connect_to_local(
-            auth_credentials=weaviate.auth.AuthApiKey(api_key=api_key) if api_key else None
-        ) as client:
+        with contextlib.ExitStack() as stack:
+            logger.info("Connect to Weaviate")
+            client = stack.enter_context(
+                weaviate.connect_to_local(
+                    auth_credentials=weaviate.auth.AuthApiKey(api_key=api_key) if api_key else None
+                )
+            )
+            # Under RBAC the workload user lacks read_tenants on Books*/Authors*, which
+            # wait_for_vector_indexing() requires (it hits GET /schema/{class}/shards).
+            # Open a separate admin connection for those readiness waits when an admin
+            # key is provided; otherwise reuse the workload client.
+            if admin_api_key and admin_api_key != api_key:
+                admin_client = stack.enter_context(
+                    weaviate.connect_to_local(
+                        auth_credentials=weaviate.auth.AuthApiKey(api_key=admin_api_key)
+                    )
+                )
+            else:
+                admin_client = client
             logger.info("Clean DB")
             client.collections.delete_all()
             logger.info("Run Multitenancy test suite")
-            multitenancy.create(client)
+            multitenancy.create(client, admin_client)
             multitenancy.sanity_checks(client)
             logger.info("Run books test suite")
-            books.create(client)
+            books.create(client, admin_client)
             books.sanity_checks(client)
         logger.success("Success")
     except:
@@ -28,5 +44,10 @@ def create(api_key=None):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--api-key", help="API key for authentication", default=None)
+    parser.add_argument(
+        "--admin-api-key",
+        help="Admin API key used only for privileged readiness waits under RBAC",
+        default=None,
+    )
     args = parser.parse_args()
-    create(args.api_key)
+    create(args.api_key, args.admin_api_key)


### PR DESCRIPTION
## Problem

When `ASYNC_INDEXING=true`, batch-imported objects are vectorized in the background. The upgrade-journey jobs imported data and then immediately ran `nearText`/`hybrid` queries — before vectorization finished — causing flaky assertion failures like:

```
assert len(result.objects) == 1  # "Snow Crash", "A Game of Thrones"
AssertionError
```

Three import functions were affected:
- `apps/upgrade-journey-raft/books.py` — `_import_books` (Books collection)
- `apps/upgrade-journey-raft/books.py` — `_import_authors` (Authors collection)
- `apps/upgrade-journey-raft/multitenancy.py` — `_import_books` (300 MTClass collections)

The `rbac-upgrade-journey` job was checked and is not affected (no vector queries).

## Fix

Added `collection.batch.wait_for_vector_indexing()` after each `batch.flush()` in all three affected import functions, following the same pattern already used in `apps/ann-benchmarks/weaviate_import.py`.

## Related

Flaky run: https://github.com/weaviate/weaviate-chaos-engineering/actions/runs/25770106112/job/75691236978