### PR TITLE
fix: retry transient post-restart per-object errors in importer-no-vector

### DIFF
--- a/apps/importer-no-vector-index/run.go
+++ b/apps/importer-no-vector-index/run.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -16,6 +17,31 @@ import (
 	"github.com/semi-technologies/weaviate-go-client/v3/weaviate/fault"
 	"github.com/semi-technologies/weaviate/entities/models"
 )
+
+// transientPerObjectErrorSubstrings lists error messages that the server may
+// return for individual objects in a batch response during a brief window
+// after the weaviate process restarts (e.g., after the chaotic-killer has
+// SIGKILLed it). In all cases the underlying state is fine — the schema is
+// persisted in RAFT, autoSchema is mid-flight, or the FSM hasn't finished
+// replaying — and a subsequent batch attempt will succeed. Treating these
+// per-object errors as fatal makes the importer flake on every kill that
+// happens to land inside a batch boundary, so we retry instead.
+var transientPerObjectErrorSubstrings = []string{
+	"not present in schema",
+	"shard not ready",
+	"local schema",
+	"context deadline exceeded",
+	"context canceled",
+}
+
+func isTransientPerObjectError(msg string) bool {
+	for _, s := range transientPerObjectErrorSubstrings {
+		if strings.Contains(msg, s) {
+			return true
+		}
+	}
+	return false
+}
 
 func main() {
 	rand.Seed(time.Now().UnixNano())
@@ -109,15 +135,30 @@ func buildAndSendBatchWithRetries(ctx context.Context, batcher *batch.ObjectsBat
 		if err != nil {
 			lastErr = getErrorWithDerivedError(err)
 			continue
-		} else {
-			for _, c := range res {
-				if c.Result != nil {
-					if c.Result.Errors != nil && c.Result.Errors.Error != nil {
-						return errors.Errorf("failed to create obj: %+v, with status: %v",
-							c.Result.Errors.Error[0], c.Result.Status)
-					}
-				}
+		}
+
+		// Walk per-object results. Transient errors (e.g. "class X not present
+		// in schema" while the just-restarted server's schema cache is still
+		// being repopulated) are expected during the *_while_crashing chaos
+		// scenarios and must be retried; any other per-object error is a real
+		// failure and aborts the import.
+		retryDueToTransient := false
+		for _, c := range res {
+			if c.Result == nil || c.Result.Errors == nil || c.Result.Errors.Error == nil {
+				continue
 			}
+			objErr := c.Result.Errors.Error[0]
+			if isTransientPerObjectError(objErr.Message) {
+				retryDueToTransient = true
+				lastErr = errors.Errorf("transient per-object error: %+v, with status: %v",
+					objErr, c.Result.Status)
+				break
+			}
+			return errors.Errorf("failed to create obj: %+v, with status: %v",
+				objErr, c.Result.Status)
+		}
+		if retryDueToTransient {
+			continue
 		}
 
 		return nil


### PR DESCRIPTION
## Summary

Closes #412.

`apps/importer-no-vector-index/run.go` was treating any per-object error in a batch response as a fatal, non-retryable failure. In the `*_while_crashing` scenarios, the first batch that lands during the brief post-restart window gets per-object errors of the form `class 'NoVector' not present in schema` while the just-restarted server is still repopulating its schema cache. The class is fully persisted in RAFT; only the in-memory cache is briefly empty.

This patch makes per-object errors whose message matches a short allowlist of known transient/restart-race patterns retryable instead of fatal. Other per-object errors still abort the import, so real failures are not masked.

## Root Cause

```
1. Importer creates schema (06:30:42) and starts batching at ~125 obj/s.
2. Chaotic-killer SIGKILLs weaviate mid-batch at 06:31:44 (~54% done).
3. Docker restarts the container (RestartPolicy: on-failure, MaxRetry=0 → unlimited).
4. Importer retries 3x on transport errors (EOF, ECONNREFUSED, ECONNRESET).
5. ~17s after kill, Weaviate is listening and accepts the 4th batch (HTTP 200).
6. But Weaviate's schema cache is still recovering: autoSchema fires per-object
   TYPE_ADD_CLASS (visible 25+ times at 06:32:01 in the server log dump);
   `fetchedClasses` map is empty.
7. weaviate/usecases/objects/batch_add.go:196-198 flags each object:
   "class 'NoVector' not present in schema".
8. Importer's for-loop at run.go:113-120 returns the first per-object error
   as fatal -> test fails.
```

Reference failing job:
https://github.com/weaviate/weaviate-chaos-engineering/actions/runs/25845589938/job/75940015183

## Changes

- `apps/importer-no-vector-index/run.go`:
  - Add `transientPerObjectErrorSubstrings` allowlist and `isTransientPerObjectError` helper.
  - In `buildAndSendBatchWithRetries`, walk per-object results and `continue` to the next retry iteration when a per-object error matches the allowlist; otherwise abort as before.

The sibling importer at `apps/importer/app.go` (used by `import_while_crashing.sh`, the with-vector variant) does not exhibit this flake because it only inspects HTTP status and never walks per-object results — this patch brings the no-vector variant into rough parity, while keeping the existing strict check for genuine per-object failures.

## Test Plan

- [ ] CI: re-run the `Heavy object store imports while crashing` matrix (both mmap + pread, async + non-async) and confirm it stays green across several runs.
- [ ] Local: run `./import_while_crashing_no_vector.sh` repeatedly and confirm no spurious failures.
- [ ] Verify that a genuine per-object error (e.g., schema validation failure unrelated to restart) still aborts the import — the new code path explicitly only retries on the allowlisted substrings.

---
*Triage and fix generated by Claude via the `triage-ci` skill.*