### PR TITLE
diag: capture inner/outer + retry on by-ref dystopian under-count

### DIFF
--- a/apps/upgrade-journey-raft/books.py
+++ b/apps/upgrade-journey-raft/books.py
@@ -34,6 +34,31 @@ def _diagnose_dystopian_undercount(client: weaviate.WeaviateClient, got: int):
 
     by_ref = Filter.by_ref("wroteBooks").by_property("genre").equal("dystopian")
     logger.error("DIAGNOSE by-ref under-count: got {} authors, expected 5", got)
+    # Forward-resolution probe: do the Author BODIES still hold their wroteBooks
+    # refs (just the inverted index lost), or are the refs gone from the bodies
+    # too (actual data loss)? Count total resolved refs across all authors at ALL.
+    fwd = (
+        client.collections.get("Authors")
+        .with_consistency_level(ConsistencyLevel.ALL)
+        .query.fetch_objects(
+            return_references=[QueryReference(link_on="wroteBooks", return_properties=["title"])],
+            limit=100,
+        )
+    )
+    total_refs = sum(
+        (
+            len(o.references["wroteBooks"].objects)
+            if o.references and "wroteBooks" in o.references
+            else 0
+        )
+        for o in fwd.objects
+    )
+    logger.error(
+        "  forward-resolution: {} authors, {} total wroteBooks refs resolved from bodies "
+        "(>0 => bodies intact, inverted-index-only loss; ~0 => refs lost from bodies too)",
+        len(fwd.objects),
+        total_refs,
+    )
     for name, cl in (
         ("ONE", ConsistencyLevel.ONE),
         ("QUORUM", ConsistencyLevel.QUORUM),

--- a/apps/upgrade-journey-raft/books.py
+++ b/apps/upgrade-journey-raft/books.py
@@ -34,12 +34,29 @@ def _diagnose_dystopian_undercount(client: weaviate.WeaviateClient, got: int):
 
     by_ref = Filter.by_ref("wroteBooks").by_property("genre").equal("dystopian")
     logger.error("DIAGNOSE by-ref under-count: got {} authors, expected 5", got)
-    for name, cl in (("ONE", ConsistencyLevel.ONE), ("QUORUM", ConsistencyLevel.QUORUM), ("ALL", ConsistencyLevel.ALL)):
-        inner = len(client.collections.get("Books").with_consistency_level(cl)
-                    .query.fetch_objects(filters=Filter.by_property("genre").equal("dystopian"), limit=100).objects)
-        outer = len(client.collections.get("Authors").with_consistency_level(cl)
-                    .query.fetch_objects(filters=by_ref, limit=100).objects)
-        logger.error("  CL={} inner Books(genre=dystopian)={} (exp 8)  outer Authors(by_ref)={} (exp 5)", name, inner, outer)
+    for name, cl in (
+        ("ONE", ConsistencyLevel.ONE),
+        ("QUORUM", ConsistencyLevel.QUORUM),
+        ("ALL", ConsistencyLevel.ALL),
+    ):
+        inner = len(
+            client.collections.get("Books")
+            .with_consistency_level(cl)
+            .query.fetch_objects(filters=Filter.by_property("genre").equal("dystopian"), limit=100)
+            .objects
+        )
+        outer = len(
+            client.collections.get("Authors")
+            .with_consistency_level(cl)
+            .query.fetch_objects(filters=by_ref, limit=100)
+            .objects
+        )
+        logger.error(
+            "  CL={} inner Books(genre=dystopian)={} (exp 8)  outer Authors(by_ref)={} (exp 5)",
+            name,
+            inner,
+            outer,
+        )
     authors_q = client.collections.get("Authors").with_consistency_level(ConsistencyLevel.QUORUM)
     converged = False
     for i in range(20):
@@ -51,7 +68,9 @@ def _diagnose_dystopian_undercount(client: weaviate.WeaviateClient, got: int):
             break
         time.sleep(2)
     if not converged:
-        logger.error("  -> still != 5 after retries => PERSISTENT (derived index incomplete / functional bug)")
+        logger.error(
+            "  -> still != 5 after retries => PERSISTENT (derived index incomplete / functional bug)"
+        )
 
 
 def sanity_checks(client: weaviate.WeaviateClient):

--- a/apps/upgrade-journey-raft/books.py
+++ b/apps/upgrade-journey-raft/books.py
@@ -24,6 +24,36 @@ def _import(client: weaviate.WeaviateClient, admin_client: weaviate.WeaviateClie
     _import_authors(client, admin_client)
 
 
+def _diagnose_dystopian_undercount(client: weaviate.WeaviateClient, got: int):
+    """On a by-ref under-count, log the decisive evidence into the CI job:
+    - decompose inner (Books genre=dystopian, exp 8) vs outer (Authors by_ref, exp 5)
+      at ONE/QUORUM/ALL -> tells us which read is short and if CL matters;
+    - retry the QUORUM by-ref query -> converges to 5 == TRANSIENT (readiness),
+      stays < 5 == PERSISTENT (derived index incomplete / functional bug)."""
+    import time
+
+    by_ref = Filter.by_ref("wroteBooks").by_property("genre").equal("dystopian")
+    logger.error("DIAGNOSE by-ref under-count: got {} authors, expected 5", got)
+    for name, cl in (("ONE", ConsistencyLevel.ONE), ("QUORUM", ConsistencyLevel.QUORUM), ("ALL", ConsistencyLevel.ALL)):
+        inner = len(client.collections.get("Books").with_consistency_level(cl)
+                    .query.fetch_objects(filters=Filter.by_property("genre").equal("dystopian"), limit=100).objects)
+        outer = len(client.collections.get("Authors").with_consistency_level(cl)
+                    .query.fetch_objects(filters=by_ref, limit=100).objects)
+        logger.error("  CL={} inner Books(genre=dystopian)={} (exp 8)  outer Authors(by_ref)={} (exp 5)", name, inner, outer)
+    authors_q = client.collections.get("Authors").with_consistency_level(ConsistencyLevel.QUORUM)
+    converged = False
+    for i in range(20):
+        n = len(authors_q.query.fetch_objects(filters=by_ref, limit=100).objects)
+        logger.error("  retry {}: authors(by_ref,QUORUM)={}", i + 1, n)
+        if n == 5:
+            logger.error("  -> converged to 5 at retry {} => TRANSIENT (readiness race)", i + 1)
+            converged = True
+            break
+        time.sleep(2)
+    if not converged:
+        logger.error("  -> still != 5 after retries => PERSISTENT (derived index incomplete / functional bug)")
+
+
 def sanity_checks(client: weaviate.WeaviateClient):
     _books_sanity_checks(client)
     _authors_sanity_checks(client)
@@ -267,6 +297,8 @@ def _authors_sanity_checks(client: weaviate.WeaviateClient):
         ],
     )
     assert result is not None
+    if len(result.objects) != 5:
+        _diagnose_dystopian_undercount(client, len(result.objects))
     assert len(result.objects) == 5
     logger.info(
         "where on reference Books genre property equal to dystopian found: {}", len(result.objects)


### PR DESCRIPTION
Diagnostic-only (no behavior change on pass). When `upgrade-journey-raft` by-ref `== 5` fails, it logs into the job:
- **inner** Books(genre=dystopian) (exp 8) vs **outer** Authors(by_ref) (exp 5) at ONE/QUORUM/ALL — pinpoints which read is short and whether CL matters;
- a **retry** loop at QUORUM — converges to 5 = TRANSIENT (readiness), stays < 5 = PERSISTENT (derived index incomplete / functional bug).

Goal: settle the root cause of the post-upgrade under-count from CI logs, since it can't be reproduced locally.