### PR TITLE
Ann benchmark tests: Disable duplication

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -567,7 +567,7 @@ jobs:
 
   ann-benchmarks-sift-gcp:
     name: "[bench GCP] SIFT1M pq=false"
-    if: ${{ github.event.inputs.test_to_run == 'ann-benchmarks-sift-gcp' || github.event.inputs.test_to_run == '' }}
+    if: false # disabled: use ann-benchmarks-sift-aws instead
     runs-on: ubicloud-standard-2
     timeout-minutes: 60
     env:
@@ -604,7 +604,7 @@ jobs:
           glob: '*.json'
   ann-benchmarks-pq-sift-gcp:
     name: "[bench GCP] SIFT1M pq=true"
-    if: ${{ github.event.inputs.test_to_run == 'ann-benchmarks-pq-sift-gcp' || github.event.inputs.test_to_run == '' }}
+    if: false # disabled: use ann-benchmarks-pq-sift-aws instead
     runs-on: ubicloud-standard-2
     timeout-minutes: 60
     env:
@@ -643,7 +643,7 @@ jobs:
 
   ann-benchmarks-rq-sift-gcp:
     needs: [newer-or-equal-than-1_32]
-    if: ${{ (needs.newer-or-equal-than-1_32.outputs.check == 'true') && (github.event.inputs.test_to_run == 'ann-benchmarks-rq-sift-gcp' || github.event.inputs.test_to_run == '') }}
+    if: false # disabled: duplicate GCP SIFT job retired in favor of AWS
     name: "[bench GCP] SIFT1M rq=true"
     runs-on: ubicloud-standard-2
     timeout-minutes: 60

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -282,7 +282,7 @@ jobs:
       - uses: psf/black@26.1.0
   ann-benchmarks-sift-aws:
     name: "[bench AWS] SIFT1M pq=false"
-    if: ${{ github.event.inputs.test_to_run == 'ann-benchmarks-sift-aws' || github.event.inputs.test_to_run == '' }}
+    if: ${{ inputs.lsm_access_strategy == 'pread' && (github.event.inputs.test_to_run == 'ann-benchmarks-sift-aws' || github.event.inputs.test_to_run == '') }}
     runs-on: ubicloud-standard-2
     timeout-minutes: 60
     env:
@@ -320,7 +320,7 @@ jobs:
           glob: '*.json'
   ann-benchmarks-glove-aws:
     name: "[bench AWS] Glove100 pq=false"
-    if: ${{ github.event.inputs.test_to_run == 'ann-benchmarks-glove-aws' || github.event.inputs.test_to_run == '' }}
+    if: ${{ inputs.lsm_access_strategy == 'pread' && (github.event.inputs.test_to_run == 'ann-benchmarks-glove-aws' || github.event.inputs.test_to_run == '') }}
     runs-on: ubicloud-standard-2
     timeout-minutes: 60
     env:
@@ -358,7 +358,7 @@ jobs:
           glob: '*.json'
   ann-benchmarks-pq-sift-aws:
     name: "[bench AWS] SIFT1M pq=true"
-    if: ${{ github.event.inputs.test_to_run == 'ann-benchmarks-pq-sift-aws' || github.event.inputs.test_to_run == '' }}
+    if: ${{ inputs.lsm_access_strategy == 'pread' && (github.event.inputs.test_to_run == 'ann-benchmarks-pq-sift-aws' || github.event.inputs.test_to_run == '') }}
     runs-on: ubicloud-standard-2
     timeout-minutes: 60
     env:
@@ -397,7 +397,7 @@ jobs:
           glob: '*.json'
   ann-benchmarks-sq-sift-aws:
     needs: [newer-or-equal-than-1_26]
-    if: ${{ (needs.newer-or-equal-than-1_26.outputs.check == 'true') && (github.event.inputs.test_to_run == 'ann-benchmarks-sq-sift-aws' || github.event.inputs.test_to_run == '')}}
+    if: ${{ inputs.lsm_access_strategy == 'pread' && (needs.newer-or-equal-than-1_26.outputs.check == 'true') && (github.event.inputs.test_to_run == 'ann-benchmarks-sq-sift-aws' || github.event.inputs.test_to_run == '')}}
     name: "[bench AWS] SIFT1M sq=true"
     runs-on: ubicloud-standard-2
     timeout-minutes: 60
@@ -437,7 +437,7 @@ jobs:
           glob: '*.json'
   ann-benchmarks-pq-glove-aws:
     name: "[bench AWS] Glove100 pq=true"
-    if: ${{ github.event.inputs.test_to_run == 'ann-benchmarks-pq-glove-aws' || github.event.inputs.test_to_run == '' }}
+    if: ${{ inputs.lsm_access_strategy == 'pread' && (github.event.inputs.test_to_run == 'ann-benchmarks-pq-glove-aws' || github.event.inputs.test_to_run == '') }}
     runs-on: ubicloud-standard-2
     timeout-minutes: 60
     env:
@@ -476,7 +476,7 @@ jobs:
           glob: '*.json'
   ann-benchmarks-sq-glove-aws:
     needs: [newer-or-equal-than-1_26]
-    if: ${{ (needs.newer-or-equal-than-1_26.outputs.check == 'true') && ( github.event.inputs.test_to_run == 'ann-benchmarks-sq-glove-aws' || github.event.inputs.test_to_run == '' ) }}
+    if: ${{ inputs.lsm_access_strategy == 'pread' && (needs.newer-or-equal-than-1_26.outputs.check == 'true') && ( github.event.inputs.test_to_run == 'ann-benchmarks-sq-glove-aws' || github.event.inputs.test_to_run == '' ) }}
     name: "[bench AWS] Glove100 sq=true"
     runs-on: ubicloud-standard-2
     timeout-minutes: 60
@@ -517,7 +517,7 @@ jobs:
 
   ann-benchmarks-rq-glove-aws:
     needs: [newer-or-equal-than-1_32]
-    if: ${{ (needs.newer-or-equal-than-1_32.outputs.check == 'true') && (github.event.inputs.test_to_run == 'ann-benchmarks-rq-glove-aws' || github.event.inputs.test_to_run == '') }}
+    if: ${{ inputs.lsm_access_strategy == 'pread' && (needs.newer-or-equal-than-1_32.outputs.check == 'true') && (github.event.inputs.test_to_run == 'ann-benchmarks-rq-glove-aws' || github.event.inputs.test_to_run == '') }}
     name: "[bench AWS] Glove100 rq=true"
     runs-on: ubicloud-standard-2
     timeout-minutes: 60
@@ -693,7 +693,7 @@ jobs:
   ann-benchmarks-multivector-gcp:
     name: "[bench GCP] MULTIVECTOR3M"
     needs: [newer-or-equal-than-1_29]
-    if: ${{ (needs.newer-or-equal-than-1_29.outputs.check == 'true') && (github.event.inputs.test_to_run == 'ann-benchmarks-multivector-gcp' || github.event.inputs.test_to_run == '' || github.event.inputs.test_to_run == 'ann-benchmarks-multivector-all') }}
+    if: ${{ inputs.lsm_access_strategy == 'pread' && (needs.newer-or-equal-than-1_29.outputs.check == 'true') && (github.event.inputs.test_to_run == 'ann-benchmarks-multivector-gcp' || github.event.inputs.test_to_run == '' || github.event.inputs.test_to_run == 'ann-benchmarks-multivector-all') }}
     runs-on: ubicloud-standard-2
     timeout-minutes: 60
     env:
@@ -732,7 +732,7 @@ jobs:
   ann-benchmarks-multivector-pq-gcp:
     name: "[bench GCP] MULTIVECTOR3M pq=true"
     needs: [newer-or-equal-than-1_30]
-    if: ${{ (needs.newer-or-equal-than-1_30.outputs.check == 'true') && (github.event.inputs.test_to_run == 'ann-benchmarks-multivector-pq-gcp' || github.event.inputs.test_to_run == '' || github.event.inputs.test_to_run == 'ann-benchmarks-multivector-all') }}
+    if: ${{ inputs.lsm_access_strategy == 'pread' && (needs.newer-or-equal-than-1_30.outputs.check == 'true') && (github.event.inputs.test_to_run == 'ann-benchmarks-multivector-pq-gcp' || github.event.inputs.test_to_run == '' || github.event.inputs.test_to_run == 'ann-benchmarks-multivector-all') }}
     runs-on: ubicloud-standard-2
     timeout-minutes: 60
     env:
@@ -772,7 +772,7 @@ jobs:
   ann-benchmarks-multivector-sq-gcp:
     name: "[bench GCP] MULTIVECTOR3M sq=true"
     needs: [newer-or-equal-than-1_30]
-    if: ${{ (needs.newer-or-equal-than-1_30.outputs.check == 'true') && (github.event.inputs.test_to_run == 'ann-benchmarks-multivector-sq-gcp' || github.event.inputs.test_to_run == '' || github.event.inputs.test_to_run == 'ann-benchmarks-multivector-all') }}
+    if: ${{ inputs.lsm_access_strategy == 'pread' && (needs.newer-or-equal-than-1_30.outputs.check == 'true') && (github.event.inputs.test_to_run == 'ann-benchmarks-multivector-sq-gcp' || github.event.inputs.test_to_run == '' || github.event.inputs.test_to_run == 'ann-benchmarks-multivector-all') }}
     runs-on: ubicloud-standard-2
     timeout-minutes: 60
     env:
@@ -812,7 +812,7 @@ jobs:
   ann-benchmarks-multivector-rq-gcp:
     name: "[bench GCP] MULTIVECTOR3M rq=true"
     needs: [newer-or-equal-than-1_32]
-    if: ${{ (needs.newer-or-equal-than-1_32.outputs.check == 'true') && (github.event.inputs.test_to_run == 'ann-benchmarks-multivector-rq-gcp' || github.event.inputs.test_to_run == '' || github.event.inputs.test_to_run == 'ann-benchmarks-multivector-all') }}
+    if: ${{ inputs.lsm_access_strategy == 'pread' && (needs.newer-or-equal-than-1_32.outputs.check == 'true') && (github.event.inputs.test_to_run == 'ann-benchmarks-multivector-rq-gcp' || github.event.inputs.test_to_run == '' || github.event.inputs.test_to_run == 'ann-benchmarks-multivector-all') }}
     runs-on: ubicloud-standard-2
     timeout-minutes: 60
     env:
@@ -860,7 +860,7 @@ jobs:
   ann-benchmarks-multivector-muvera-gcp:
     name: "[bench GCP] MULTIVECTOR MUVERA"
     needs: [newer-or-equal-than-1_31]
-    if: ${{ (needs.newer-or-equal-than-1_31.outputs.check == 'true') && (github.event.inputs.test_to_run == 'ann-benchmarks-multivector-muvera-gcp' || github.event.inputs.test_to_run == '' || github.event.inputs.test_to_run == 'ann-benchmarks-multivector-all') }}
+    if: ${{ inputs.lsm_access_strategy == 'pread' && (needs.newer-or-equal-than-1_31.outputs.check == 'true') && (github.event.inputs.test_to_run == 'ann-benchmarks-multivector-muvera-gcp' || github.event.inputs.test_to_run == '' || github.event.inputs.test_to_run == 'ann-benchmarks-multivector-all') }}
     runs-on: ubicloud-standard-2
     timeout-minutes: 60
     env:
@@ -911,7 +911,7 @@ jobs:
   ann-benchmarks-multivector-muvera-gcp-sq:
     name: "[bench GCP] MULTIVECTOR MUVERA and SQ"
     needs: [newer-or-equal-than-1_31]
-    if: ${{ (needs.newer-or-equal-than-1_31.outputs.check == 'true') && (github.event.inputs.test_to_run == 'ann-benchmarks-multivector-muvera-gcp' || github.event.inputs.test_to_run == '' || github.event.inputs.test_to_run == 'ann-benchmarks-multivector-all') }}
+    if: ${{ inputs.lsm_access_strategy == 'pread' && (needs.newer-or-equal-than-1_31.outputs.check == 'true') && (github.event.inputs.test_to_run == 'ann-benchmarks-multivector-muvera-gcp' || github.event.inputs.test_to_run == '' || github.event.inputs.test_to_run == 'ann-benchmarks-multivector-all') }}
     runs-on: ubicloud-standard-2
     timeout-minutes: 60
     env:
@@ -956,7 +956,7 @@ jobs:
   ann-benchmarks-multivector-muvera-gcp-rq:
     name: "[bench GCP] MULTIVECTOR MUVERA and RQ"
     needs: [newer-or-equal-than-1_32]
-    if: ${{ (needs.newer-or-equal-than-1_32.outputs.check == 'true') && (github.event.inputs.test_to_run == 'ann-benchmarks-multivector-muvera-gcp-rq' || github.event.inputs.test_to_run == '' || github.event.inputs.test_to_run == 'ann-benchmarks-multivector-all') }}
+    if: ${{ inputs.lsm_access_strategy == 'pread' && (needs.newer-or-equal-than-1_32.outputs.check == 'true') && (github.event.inputs.test_to_run == 'ann-benchmarks-multivector-muvera-gcp-rq' || github.event.inputs.test_to_run == '' || github.event.inputs.test_to_run == 'ann-benchmarks-multivector-all') }}
     runs-on: ubicloud-standard-2
     timeout-minutes: 60
     env:


### PR DESCRIPTION
## Summary

- Disable GCP SIFT ANN benchmark jobs (`sift`, `pq-sift`, `rq-sift`) in favor of their AWS equivalents.
- Run all ANN benchmark jobs only on the `pread` LSM access strategy matrix leg, skipping `mmap`.
- Keep GCP multivector benchmarks (no AWS equivalent), also limited to `pread`.

This removes redundant ANN benchmark runs that no longer add value, while leaving other chaos tests on both `mmap` and `pread`.

## Test plan

- [ ] Run the test matrix workflow and confirm ANN jobs only run under the `pread` leg
- [ ] Confirm non-ANN chaos tests still run on both `mmap` and `pread`