### PR TITLE
Fix compactv2 version gate to match 1.39+ as intended

### DIFF
--- a/condensing_while_crash.sh
+++ b/condensing_while_crash.sh
@@ -78,7 +78,7 @@ wait_for_condensing() {
     version_minor=$(echo "$version" | cut -d. -f2)
 
     local grep_pattern
-    if [ "$version_major" -gt 1 ] || { [ "$version_major" -eq 1 ] && [ "$version_minor" -ge 38 ]; }; then
+    if [ "$version_major" -gt 1 ] || { [ "$version_major" -eq 1 ] && [ "$version_minor" -ge 39 ]; }; then
         grep_pattern="hnsw_compactor_merge|hnsw_compactor_snapshot|hnsw_compactor_convert"
         echo "Weaviate >= 1.39 detected (${version}), waiting for compactv2 activity"
     else

--- a/hnsw_snapshotting_while_crash.sh
+++ b/hnsw_snapshotting_while_crash.sh
@@ -108,7 +108,7 @@ wait_for_hnsw_snapshot() {
     version_minor=$(echo "$version" | cut -d. -f2)
 
     local use_compactv2=false
-    if [ "$version_major" -gt 1 ] || { [ "$version_major" -eq 1 ] && [ "$version_minor" -ge 38 ]; }; then
+    if [ "$version_major" -gt 1 ] || { [ "$version_major" -eq 1 ] && [ "$version_minor" -ge 39 ]; }; then
         use_compactv2=true
         echo "Weaviate >= 1.39 detected (${version}), waiting for compactv2 snapshot"
     else


### PR DESCRIPTION
## Problem

`condensing_while_crash.sh` and `hnsw_snapshotting_while_crash.sh` detect the Weaviate version to decide which log pattern to wait for. The comment says compactv2 replaced the old condensor/snapshot mechanism in **1.39+**, but the check compared against **38**, so 1.38.x was routed down the compactv2 path:

```
Weaviate >= 1.39 detected (1.38), waiting for compactv2 activity
```

Against 1.38 images (e.g. `prepare-release-v1.38.3` in [run 28943146266](https://github.com/weaviate/weaviate-chaos-engineering/actions/runs/28943146266)), both tests grep for `hnsw_compactor_*` messages that 1.38 never emits and time out after 150 attempts — even though the container logs show condensing actually completed fine via the legacy path (`start hnsw condensing`).

## Fix

Change the minor-version threshold from `-ge 38` to `-ge 39` in both scripts so 1.38.x uses the legacy log patterns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)