### PR TITLE
Add JUnit XML result generation to all chaos test jobs

### DIFF
--- a/.github/actions/report-job-junit/action.yml
+++ b/.github/actions/report-job-junit/action.yml
@@ -1,0 +1,42 @@
+name: 'Report job result as JUnit'
+description: >-
+  Records the whole job's outcome as a single JUnit <testcase> named after the
+  job key in test-results.xml. Meant for multi-step journey jobs where any of
+  many steps (including uses: steps that cannot be wrapped) may fail: place it
+  as the LAST step with `if: always()`. On failure it downloads this job's own
+  log through the GitHub API (the failed step has already completed, so its
+  log section is available mid-run) and extracts the culprit (python
+  traceback, go panic, docker build error, ...) as the failure body. Never
+  fails the job.
+inputs:
+  job-status:
+    description: 'Pass ${{ job.status }}'
+    required: true
+  lsm-access-strategy:
+    description: mmap or pread; names the JUnit suite and the artifact
+    required: true
+  github-token:
+    description: 'Pass ${{ github.token }} (needs actions: read)'
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Record JUnit result
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+      run: |
+        python3 "$GITHUB_WORKSPACE/.github/scripts/chaos_junit.py" report-job \
+          --file "$GITHUB_WORKSPACE/test-results.xml" \
+          --suite 'chaos-${{ inputs.lsm-access-strategy }}' \
+          --name '${{ github.job }}' \
+          --job-status '${{ inputs.job-status }}' \
+          || echo "::warning::chaos_junit report-job failed; no JUnit result recorded"
+    - name: Upload JUnit artifact
+      uses: actions/upload-artifact@v5
+      continue-on-error: true
+      with:
+        name: junit-${{ github.job }}-${{ inputs.lsm-access-strategy }}
+        path: test-results.xml
+        overwrite: true
+        if-no-files-found: warn

--- a/.github/actions/report-job-junit/action.yml
+++ b/.github/actions/report-job-junit/action.yml
@@ -10,13 +10,13 @@ description: >-
   fails the job.
 inputs:
   job-status:
-    description: 'Pass ${{ job.status }}'
+    description: The caller's job.status expression
     required: true
   lsm-access-strategy:
     description: mmap or pread; names the JUnit suite and the artifact
     required: true
   github-token:
-    description: 'Pass ${{ github.token }} (needs actions: read)'
+    description: A token with actions:read (the caller's github.token)
     required: true
 runs:
   using: composite

--- a/.github/actions/run-chaos-test/action.yml
+++ b/.github/actions/run-chaos-test/action.yml
@@ -1,0 +1,93 @@
+name: 'Run chaos test'
+description: >-
+  Runs a chaos test command, records the result as a JUnit <testcase> in
+  test-results.xml at the workspace root, uploads it as an artifact, and exits
+  with the command's original exit code. test-results.xml is the contract the
+  weaviate-test-reporter step (added per job in a follow-up) consumes in-job,
+  which is required for it to resolve the correct run/job URLs.
+inputs:
+  command:
+    description: Shell command that runs the test (executed via bash -ec)
+    required: true
+  lsm-access-strategy:
+    description: mmap or pread; names the JUnit suite and the artifact
+    required: true
+  test-name-suffix:
+    description: >-
+      Appended to the job key to name the JUnit testcase (e.g. "panic-check"
+      -> "<job>-panic-check"). Required when a job wraps more than one
+      command; empty means the testcase is named after the job key alone.
+    required: false
+    default: ''
+  timeout:
+    description: >-
+      Soft timeout (GNU timeout duration, e.g. 55m); "0" disables it. Keep it
+      below the job-level timeout-minutes so a hung test still produces a
+      JUnit result instead of being hard-killed with no report.
+    required: false
+    default: '55m'
+runs:
+  using: composite
+  steps:
+    - name: Resolve test name
+      id: meta
+      shell: bash
+      run: |
+        name='${{ github.job }}'
+        suffix='${{ inputs.test-name-suffix }}'
+        [ -n "$suffix" ] && name="$name-$suffix"
+        echo "name=$name" >> "$GITHUB_OUTPUT"
+    - name: Run test
+      id: run
+      shell: bash
+      env:
+        CHAOS_COMMAND: ${{ inputs.command }}
+        CHAOS_TIMEOUT: ${{ inputs.timeout }}
+        # inside the workspace so the artifact keeps a flat layout (multi-root
+        # upload paths would nest test-results.xml under the workspace path)
+        CHAOS_LOG: ${{ github.workspace }}/chaos-output-${{ steps.meta.outputs.name }}.log
+      run: |
+        set +e
+        start_epoch=$(date +%s)
+        echo "start_iso=$(date -u +%Y-%m-%dT%H:%M:%S)" >> "$GITHUB_OUTPUT"
+        if [ "$CHAOS_TIMEOUT" = "0" ]; then
+          bash -ec "$CHAOS_COMMAND" 2>&1 | tee "$CHAOS_LOG"
+        else
+          # --kill-after must outlast common.sh's TERM trap (diagnostics dump
+          # + docker teardown) or the dump gets cut short by SIGKILL
+          timeout --signal=TERM --kill-after=60s "$CHAOS_TIMEOUT" \
+            bash -ec "$CHAOS_COMMAND" 2>&1 | tee "$CHAOS_LOG"
+        fi
+        exit_code=${PIPESTATUS[0]}
+        # the raw log is only uploaded for failed tests; green output is
+        # already in the step log
+        [ "$exit_code" = "0" ] && rm -f "$CHAOS_LOG"
+        echo "exit_code=$exit_code" >> "$GITHUB_OUTPUT"
+        echo "duration=$(( $(date +%s) - start_epoch ))" >> "$GITHUB_OUTPUT"
+        exit 0
+    - name: Record JUnit result
+      shell: bash
+      run: |
+        python3 "$GITHUB_WORKSPACE/.github/scripts/chaos_junit.py" append \
+          --file "$GITHUB_WORKSPACE/test-results.xml" \
+          --suite 'chaos-${{ inputs.lsm-access-strategy }}' \
+          --name '${{ steps.meta.outputs.name }}' \
+          --exit-code '${{ steps.run.outputs.exit_code }}' \
+          --time '${{ steps.run.outputs.duration }}' \
+          --timestamp '${{ steps.run.outputs.start_iso }}' \
+          --timeout-label '${{ inputs.timeout }}' \
+          --output-log '${{ github.workspace }}/chaos-output-${{ steps.meta.outputs.name }}.log' \
+          || echo "::warning::chaos_junit append failed; no JUnit result recorded"
+    - name: Upload JUnit artifact
+      uses: actions/upload-artifact@v5
+      continue-on-error: true
+      with:
+        name: junit-${{ github.job }}-${{ inputs.lsm-access-strategy }}
+        path: |
+          test-results.xml
+          chaos-output-*.log
+        overwrite: true
+        if-no-files-found: warn
+    - name: Propagate test exit code
+      shell: bash
+      run: exit '${{ steps.run.outputs.exit_code }}'

--- a/.github/scripts/chaos_junit.py
+++ b/.github/scripts/chaos_junit.py
@@ -1,0 +1,474 @@
+#!/usr/bin/env python3
+"""Record chaos-test results as JUnit XML (stdlib only, runs on bare runners).
+
+Chaos tests are ad-hoc shell/python/go programs with no native JUnit output, so
+CI jobs record one <testcase> per test into test-results.xml at the workspace
+root — the same contract pytest gives the e2e repo — for consumption by the
+weaviate-test-reporter action running later in the same job.
+
+Subcommands:
+  append      Record the result of one wrapped command (used by the
+              run-chaos-test composite action). Reads the command's captured
+              output to extract the failure culprit.
+  report-job  Record one job-level result (used by report-job-junit in
+              multi-step "journey" jobs). On failure it downloads this job's
+              own log through the GitHub API — mid-run, which works because
+              the failed step has already completed — and extracts the
+              culprit from the failing step's section.
+
+Culprit extraction knows three failure dialects (python traceback, go
+panic/FAIL, docker build error) and cuts away the diagnostics dump that
+common.sh's failure trap prints AFTER the real error, so the JUnit failure
+body carries the cause rather than the tail of a container-log dump.
+"""
+
+import argparse
+import json
+import os
+import re
+import sys
+import time
+import urllib.error
+import urllib.request
+import xml.etree.ElementTree as ET
+from datetime import datetime, timezone
+
+ANSI_RE = re.compile(r"\x1b\[[0-9;]*[A-Za-z]")
+# Valid XML 1.0 chars only (tab/newline/CR plus printable planes)
+XML_INVALID_RE = re.compile("[^\x09\x0a\x0d\x20-\ud7ff\ue000-\ufffd\U00010000-\U0010ffff]")
+LOG_TS_PREFIX_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\S+Z ?")
+
+# explicit marker printed by common.sh's failure trap right before its dump
+DIAG_MARKER = "===CHAOS-DIAGNOSTICS-BEGIN==="
+# fallback for logs produced without the marker (scripts that don't source
+# the current common.sh). "DIAGNOSTIC REPORT FOR:" is deliberately NOT a
+# sentinel: wait_weaviate prints it BEFORE failing, as the primary diagnosis
+DIAG_FALLBACK = "ABBREVIATED LOGS (first 30"
+
+# bound how much of a (potentially huge) log is held in memory: culprits and
+# the diagnostics dump both live at the tail
+MAX_INPUT_BYTES = 16 * 1024 * 1024
+
+PY_TRACEBACK = "Traceback (most recent call last):"
+PY_CHAIN_RE = re.compile(
+    r"During handling of the above exception|" r"The above exception was the direct cause"
+)
+GO_ANCHOR_RE = re.compile(r"panic: |fatal error: |--- FAIL|goroutine \d+ \[running\]")
+DOCKER_ANCHOR_RE = re.compile(r"ERROR: failed to (build|solve)")
+
+MESSAGE_RE = re.compile(
+    r"Exception|[A-Za-z]\w*Error\b|\bERROR\b|\b[Ee]rror:|panic: |assert|FAIL|"
+    r"[Ff]ailed|fatal|[Tt]imed? ?out|Timeout"
+)
+MESSAGE_NOISE_RE = re.compile(
+    r"^\s*$|Retrying in |% complete|##\[|command terminated with exit code|"
+    r'store logs|\[OK\]|=====|Node 20 is being deprecated|"Error":'
+)
+
+MAX_BODY_LINES = 400
+MAX_MESSAGE_CHARS = 300
+
+
+def sanitize(text):
+    text = text.replace("\r\n", "\n").replace("\r", "\n")
+    text = ANSI_RE.sub("", text)
+    return XML_INVALID_RE.sub("", text)
+
+
+def split_diagnostics(lines):
+    """Return the lines before common.sh's failure-trap dump (if any)."""
+    for i, line in enumerate(lines):
+        if DIAG_MARKER in line:
+            return lines[:i]
+    for i, line in enumerate(lines):
+        if DIAG_FALLBACK in line:
+            # the dump is introduced by a bare "=====..." separator line
+            cut = i
+            if cut > 0 and set(lines[cut - 1].strip()) == {"="}:
+                cut -= 1
+            return lines[:cut]
+    return lines
+
+
+def _python_block_start(lines, last_tb):
+    """Walk chained tracebacks upward from the last one."""
+    start = last_tb
+    while True:
+        prev_tb = None
+        for j in range(start - 1, -1, -1):
+            if PY_TRACEBACK in lines[j]:
+                prev_tb = j
+                break
+        if prev_tb is None:
+            return start
+        between = lines[prev_tb:start]
+        if any(PY_CHAIN_RE.search(line) for line in between):
+            start = prev_tb
+        else:
+            return start
+
+
+def extract_culprit(text, tail_lines):
+    """Return (message, body) for a failure, from sanitized raw output."""
+    lines = split_diagnostics(sanitize(text).split("\n"))
+
+    dialects = (
+        ("python", lambda line: PY_TRACEBACK in line),
+        ("go", GO_ANCHOR_RE.search),
+        ("docker", DOCKER_ANCHOR_RE.search),
+    )
+    anchors = []
+    for kind, matches in dialects:
+        for i in range(len(lines) - 1, -1, -1):
+            if matches(lines[i]):
+                anchors.append((i, kind))
+                break
+
+    if anchors:
+        idx, kind = max(anchors)
+        if kind == "python":
+            start = _python_block_start(lines, idx)
+        elif kind == "docker":
+            start = max(0, idx - 40)
+        else:
+            start = idx
+        body_lines = lines[start:]
+    else:
+        body_lines = lines[-tail_lines:]
+    body_lines = body_lines[-MAX_BODY_LINES:]
+
+    message = None
+    for candidates in (body_lines, lines):
+        for line in reversed(candidates):
+            stripped = line.strip()
+            if not stripped or MESSAGE_NOISE_RE.search(stripped):
+                continue
+            if MESSAGE_RE.search(stripped):
+                message = stripped[:MAX_MESSAGE_CHARS]
+                break
+        if message:
+            break
+
+    return message, "\n".join(body_lines).strip()
+
+
+# ---------------------------------------------------------------- junit file
+
+
+def load_or_create(path):
+    if os.path.exists(path):
+        try:
+            root = ET.parse(path).getroot()
+        except ET.ParseError:
+            # a corrupt file must not cost us this test's result
+            os.replace(path, path + ".corrupt")
+            return ET.Element("testsuites")
+        if root.tag == "testsuite":  # tolerate a bare-suite file
+            new_root = ET.Element("testsuites")
+            new_root.append(root)
+            root = new_root
+        return root
+    return ET.Element("testsuites")
+
+
+def get_suite(root, name):
+    for suite in root.findall("testsuite"):
+        if suite.get("name") == name:
+            return suite
+    suite = ET.SubElement(root, "testsuite", name=name)
+    return suite
+
+
+def refresh_counts(root):
+    total = {"tests": 0, "failures": 0, "errors": 0, "skipped": 0, "time": 0.0}
+    for suite in root.findall("testsuite"):
+        counts = {"tests": 0, "failures": 0, "errors": 0, "skipped": 0, "time": 0.0}
+        for case in suite.findall("testcase"):
+            counts["tests"] += 1
+            counts["time"] += float(case.get("time") or 0)
+            if case.find("failure") is not None:
+                counts["failures"] += 1
+            if case.find("error") is not None:
+                counts["errors"] += 1
+            if case.find("skipped") is not None:
+                counts["skipped"] += 1
+        for key, value in counts.items():
+            suite.set(key, f"{value:.3f}" if key == "time" else str(value))
+            total[key] += value
+    for key, value in total.items():
+        root.set(key, f"{value:.3f}" if key == "time" else str(value))
+
+
+def add_case(
+    path, suite_name, case_name, classname, seconds, timestamp, result, message=None, body=None
+):
+    """result: one of 'pass', 'fail', 'timeout', 'error'."""
+    root = load_or_create(path)
+    suite = get_suite(root, suite_name)
+    if timestamp and not suite.get("timestamp"):
+        suite.set("timestamp", timestamp)
+
+    case = ET.SubElement(
+        suite,
+        "testcase",
+        name=case_name,
+        classname=classname,
+        time=f"{seconds:.3f}",
+    )
+    if result != "pass":
+        tag = "error" if result == "error" else "failure"
+        failure_type = {
+            "fail": "TestFailure",
+            "timeout": "Timeout",
+            "error": "JobError",
+        }[result]
+        el = ET.SubElement(case, tag, type=failure_type)
+        el.set("message", sanitize(message or "test failed"))
+        el.text = sanitize(body or "")
+
+    refresh_counts(root)
+    ET.indent(root)
+    tmp = path + ".tmp"
+    ET.ElementTree(root).write(tmp, encoding="UTF-8", xml_declaration=True)
+    os.replace(tmp, path)
+
+
+# ---------------------------------------------------------------- subcommands
+
+
+DURATION_UNITS = {"": 1, "s": 1, "m": 60, "h": 3600, "d": 86400}
+
+
+def parse_timeout_label(label):
+    """GNU timeout duration ('55m', '90s', '2h') -> seconds, or None."""
+    m = re.fullmatch(r"(\d+(?:\.\d+)?)([smhd]?)", (label or "").strip())
+    return float(m.group(1)) * DURATION_UNITS[m.group(2)] if m else None
+
+
+def _is_soft_timeout(args):
+    """timeout(1) exits 124 (TERM honored) or 137 (KILL escalation, e.g. when
+    common.sh's TERM trap outlives --kill-after). Guard on elapsed time so a
+    test's own quick 124/137 exit is not misread as our soft timeout."""
+    limit = parse_timeout_label(args.timeout_label)
+    if not limit:
+        return False
+    return args.exit_code in (124, 137) and args.time >= limit * 0.95
+
+
+def cmd_append(args):
+    exit_code = args.exit_code
+    if exit_code == 0:
+        result, message, body = "pass", None, None
+    else:
+        output = ""
+        if args.output_log and os.path.exists(args.output_log):
+            size = os.path.getsize(args.output_log)
+            with open(args.output_log, "rb") as f:
+                if size > MAX_INPUT_BYTES:
+                    f.seek(size - MAX_INPUT_BYTES)
+                output = f.read().decode(errors="replace")
+        message, body = extract_culprit(output, args.tail_lines)
+        if _is_soft_timeout(args):
+            result = "timeout"
+            # keep the extracted evidence: a late exit 137 can also be a
+            # genuine OOM kill, and even for a real hang the last output helps
+            timeout_msg = f"test timed out after {args.timeout_label} (soft limit)"
+            message = f"{timeout_msg}; last output: {message}" if message else timeout_msg
+        else:
+            result = "fail"
+            message = message or f"exited with code {exit_code}"
+        body = f"(exit code {exit_code})\n{body or ''}".strip()
+
+    add_case(
+        args.file,
+        args.suite,
+        args.name,
+        args.classname or args.suite,
+        args.time,
+        args.timestamp,
+        result,
+        message,
+        body,
+    )
+    print(f"chaos_junit: recorded {args.name} [{result}] in {args.file}")
+
+
+def _api(url, token):
+    req = urllib.request.Request(url)
+    req.add_header("Authorization", f"Bearer {token}")
+    req.add_header("Accept", "application/vnd.github+json")
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        return resp.read()
+
+
+class _NoRedirect(urllib.request.HTTPRedirectHandler):
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        return None
+
+
+def _read_tail(resp):
+    """Read a response in chunks, keeping only the last MAX_INPUT_BYTES —
+    job logs can be huge and the failing step's section lives at the tail."""
+    buf = bytearray()
+    while True:
+        chunk = resp.read(1024 * 1024)
+        if not chunk:
+            return bytes(buf)
+        buf.extend(chunk)
+        if len(buf) > 2 * MAX_INPUT_BYTES:
+            del buf[:-MAX_INPUT_BYTES]
+
+
+def _download_logs(url, token):
+    """The /logs endpoint 302-redirects to blob storage, which rejects
+    requests carrying the GitHub Authorization header — follow the redirect
+    manually and fetch the signed URL without auth."""
+    req = urllib.request.Request(url)
+    req.add_header("Authorization", f"Bearer {token}")
+    opener = urllib.request.build_opener(_NoRedirect)
+    try:
+        with opener.open(req, timeout=30) as resp:
+            return _read_tail(resp)
+    except urllib.error.HTTPError as err:
+        if err.code in (301, 302, 303, 307, 308):
+            location = err.headers["Location"]
+            with urllib.request.urlopen(location, timeout=60) as resp:
+                return _read_tail(resp)
+        raise
+
+
+def find_current_job(token):
+    api = os.environ.get("GITHUB_API_URL", "https://api.github.com").rstrip("/")
+    repo = os.environ["GITHUB_REPOSITORY"]
+    run_id = os.environ["GITHUB_RUN_ID"]
+    attempt = os.environ.get("GITHUB_RUN_ATTEMPT", "1")
+    runner = os.environ.get("RUNNER_NAME", "")
+    for page in range(1, 11):
+        url = (
+            f"{api}/repos/{repo}/actions/runs/{run_id}/attempts/{attempt}"
+            f"/jobs?per_page=100&page={page}"
+        )
+        jobs = json.loads(_api(url, token)).get("jobs", [])
+        if not jobs:
+            break
+        for job in jobs:
+            # only an in_progress job can be us; a completed job with the
+            # same runner name is an earlier job on a recycled runner
+            if job.get("runner_name") == runner and job.get("status") == "in_progress":
+                return job
+    return None
+
+
+def failing_section(log_text, tail_lines):
+    """Lines of the failing step: last ##[group]Run before the FIRST
+    '##[error]Process completed' marker (later ##[error] lines are
+    telemetry-action noise)."""
+    lines = log_text.split("\n")
+    end = None
+    for i, line in enumerate(lines):
+        if (
+            "##[error]Process completed with exit code" in line
+            or "##[error]The operation was canceled" in line
+        ):
+            end = i
+            break
+    if end is None:
+        return lines[-tail_lines:]
+    start = 0
+    for i in range(end - 1, -1, -1):
+        if "##[group]Run " in lines[i]:
+            start = i
+            break
+    return lines[start:end][-2000:]
+
+
+def cmd_report_job(args):
+    token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN") or ""
+    job = None
+    try:
+        job = find_current_job(token) if token else None
+    except Exception as exc:  # never fail the job over reporting
+        print(f"chaos_junit: job lookup failed: {exc}", file=sys.stderr)
+
+    seconds = 0.0
+    timestamp = None
+    job_url = None
+    if job:
+        job_url = job.get("html_url")
+        started = job.get("started_at")
+        if started:
+            timestamp = started.rstrip("Z")
+            start_dt = datetime.fromisoformat(started.replace("Z", "+00:00"))
+            seconds = (datetime.now(timezone.utc) - start_dt).total_seconds()
+
+    status = args.job_status.lower()
+    if status == "success":
+        result, message, body = "pass", None, None
+    else:
+        message, body = None, ""
+        if job and token:
+            for attempt in range(3):
+                try:
+                    api = os.environ.get("GITHUB_API_URL", "https://api.github.com").rstrip("/")
+                    repo = os.environ["GITHUB_REPOSITORY"]
+                    raw = _download_logs(
+                        f"{api}/repos/{repo}/actions/jobs/{job['id']}/logs", token
+                    ).decode(errors="replace")
+                    section = failing_section(raw, args.tail_lines)
+                    section = [LOG_TS_PREFIX_RE.sub("", line) for line in section]
+                    message, body = extract_culprit("\n".join(section), args.tail_lines)
+                    break
+                except Exception as exc:
+                    print(
+                        f"chaos_junit: log fetch attempt {attempt + 1} " f"failed: {exc}",
+                        file=sys.stderr,
+                    )
+                    time.sleep(5)
+        result = "error" if status == "cancelled" else "fail"
+        message = message or f"job finished with status {status}"
+        if job_url:
+            body = f"{body}\n\nJob log: {job_url}".strip()
+
+    add_case(
+        args.file,
+        args.suite,
+        args.name,
+        args.classname or args.suite,
+        seconds,
+        timestamp,
+        result,
+        message,
+        body,
+    )
+    print(f"chaos_junit: recorded {args.name} [{result}] in {args.file}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    common = argparse.ArgumentParser(add_help=False)
+    common.add_argument("--file", required=True)
+    common.add_argument("--suite", required=True)
+    common.add_argument("--name", required=True)
+    common.add_argument("--classname", default=None, help="defaults to --suite")
+    common.add_argument("--tail-lines", type=int, default=120)
+
+    p = sub.add_parser("append", parents=[common])
+    p.add_argument("--exit-code", type=int, required=True)
+    p.add_argument("--time", type=float, default=0.0)
+    p.add_argument("--timestamp", default=None)
+    p.add_argument("--output-log", default=None)
+    p.add_argument("--timeout-label", default="")
+    p.set_defaults(func=cmd_append)
+
+    p = sub.add_parser("report-job", parents=[common])
+    p.add_argument("--job-status", required=True)
+    p.set_defaults(func=cmd_report_job)
+
+    args = parser.parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -274,7 +274,11 @@ jobs:
       - name: Collect Workflow Telemetry
         uses: catchpoint/workflow-telemetry-action@master
       - name: Run chaos test
-        run: ./filter_memory_leak.sh
+        uses: ./.github/actions/run-chaos-test
+        with:
+          command: ./filter_memory_leak.sh
+          lsm-access-strategy: ${{ inputs.lsm_access_strategy }}
+          timeout: '0'
   lint:
     runs-on: ubicloud-standard-2
     steps:
@@ -308,7 +312,10 @@ jobs:
         uses: 'google-github-actions/setup-gcloud@v3'
       - name: Run chaos test
         if: always()
-        run: ./ann_benchmark_aws.sh
+        uses: ./.github/actions/run-chaos-test
+        with:
+          command: ./ann_benchmark_aws.sh
+          lsm-access-strategy: ${{ inputs.lsm_access_strategy }}
       - name: Cleanup AWS resources
         if: always()
         run: ./cleanup_aws_resources.sh
@@ -346,7 +353,10 @@ jobs:
         uses: 'google-github-actions/setup-gcloud@v3'
       - name: Run chaos test
         if: always()
-        run: ./ann_benchmark_aws.sh
+        uses: ./.github/actions/run-chaos-test
+        with:
+          command: ./ann_benchmark_aws.sh
+          lsm-access-strategy: ${{ inputs.lsm_access_strategy }}
       - name: Cleanup AWS resources
         if: always()
         run: ./cleanup_aws_resources.sh
@@ -385,7 +395,10 @@ jobs:
         uses: 'google-github-actions/setup-gcloud@v3'
       - name: Run chaos test
         if: always()
-        run: ./ann_benchmark_quantization_aws.sh
+        uses: ./.github/actions/run-chaos-test
+        with:
+          command: ./ann_benchmark_quantization_aws.sh
+          lsm-access-strategy: ${{ inputs.lsm_access_strategy }}
       - name: Cleanup AWS resources
         if: always()
         run: ./cleanup_aws_resources.sh
@@ -425,7 +438,10 @@ jobs:
         uses: 'google-github-actions/setup-gcloud@v3'
       - name: Run chaos test
         if: always()
-        run: ./ann_benchmark_quantization_aws.sh
+        uses: ./.github/actions/run-chaos-test
+        with:
+          command: ./ann_benchmark_quantization_aws.sh
+          lsm-access-strategy: ${{ inputs.lsm_access_strategy }}
       - name: Cleanup AWS resources
         if: always()
         run: ./cleanup_aws_resources.sh
@@ -464,7 +480,10 @@ jobs:
         uses: 'google-github-actions/setup-gcloud@v3'
       - name: Run chaos test
         if: always()
-        run: ./ann_benchmark_quantization_aws.sh
+        uses: ./.github/actions/run-chaos-test
+        with:
+          command: ./ann_benchmark_quantization_aws.sh
+          lsm-access-strategy: ${{ inputs.lsm_access_strategy }}
       - name: Cleanup AWS resources
         if: always()
         run: ./cleanup_aws_resources.sh
@@ -504,7 +523,10 @@ jobs:
         uses: 'google-github-actions/setup-gcloud@v3'
       - name: Run chaos test
         if: always()
-        run: ./ann_benchmark_quantization_aws.sh
+        uses: ./.github/actions/run-chaos-test
+        with:
+          command: ./ann_benchmark_quantization_aws.sh
+          lsm-access-strategy: ${{ inputs.lsm_access_strategy }}
       - name: Cleanup AWS resources
         if: always()
         run: ./cleanup_aws_resources.sh
@@ -547,13 +569,22 @@ jobs:
         if: always()
         env:
           RQ_BITS: 8
-        run: ./ann_benchmark_quantization_aws.sh
+        uses: ./.github/actions/run-chaos-test
+        with:
+          command: ./ann_benchmark_quantization_aws.sh
+          lsm-access-strategy: ${{ inputs.lsm_access_strategy }}
+          timeout: '35m'
       - name: Run chaos test with RQ with one bit
         if: ${{ needs.newer-or-equal-than-1_33.outputs.check == 'true' }}
         env:
           RQ_BITS: 1
           REQUIRED_RECALL: 0.55
-        run: ./ann_benchmark_quantization_aws.sh
+        uses: ./.github/actions/run-chaos-test
+        with:
+          command: ./ann_benchmark_quantization_aws.sh
+          lsm-access-strategy: ${{ inputs.lsm_access_strategy }}
+          test-name-suffix: rq-1bit
+          timeout: '20m'
       - name: Cleanup AWS resources
         if: always()
         run: ./cleanup_aws_resources.sh
@@ -719,7 +750,10 @@ jobs:
         uses: 'google-github-actions/setup-gcloud@v3'
       - name: Run chaos test
         if: always()
-        run: ./ann_benchmark_gcp.sh
+        uses: ./.github/actions/run-chaos-test
+        with:
+          command: ./ann_benchmark_gcp.sh
+          lsm-access-strategy: ${{ inputs.lsm_access_strategy }}
       - name: Cleanup GCP resources
         if: always()
         run: ./cleanup_gcp_resources.sh
@@ -759,7 +793,10 @@ jobs:
         uses: 'google-github-actions/setup-gcloud@v3'
       - name: Run chaos test
         if: always()
-        run: ./ann_benchmark_quantization_gcp.sh
+        uses: ./.github/actions/run-chaos-test
+        with:
+          command: ./ann_benchmark_quantization_gcp.sh
+          lsm-access-strategy: ${{ inputs.lsm_access_strategy }}
       - name: Cleanup GCP resources
         if: always()
         run: ./cleanup_gcp_resources.sh
@@ -799,7 +836,10 @@ jobs:
         uses: 'google-github-actions/setup-gcloud@v3'
       - name: Run chaos test
         if: always()
-        run: ./ann_benchmark_quantization_gcp.sh
+        uses: ./.github/actions/run-chaos-test
+        with:
+          command: ./ann_benchmark_quantization_gcp.sh
+          lsm-access-strategy: ${{ inputs.lsm_access_strategy }}
       - name: Cleanup GCP resources
         if: always()
         run: ./cleanup_gcp_resources.sh
@@ -841,12 +881,21 @@ jobs:
         if: always()
         env:
           RQ_BITS: 8
-        run: ./ann_benchmark_quantization_gcp.sh
+        uses: ./.github/actions/run-chaos-test
+        with:
+          command: ./ann_benchmark_quantization_gcp.sh
+          lsm-access-strategy: ${{ inputs.lsm_access_strategy }}
+          timeout: '30m'
       - name: Run chaos test with RQ with one bit
         if: ${{ needs.newer-or-equal-than-1_33.outputs.check == 'true' }}
         env:
           RQ_BITS: 1
-        run: ./ann_benchmark_quantization_gcp.sh
+        uses: ./.github/actions/run-chaos-test
+        with:
+          command: ./ann_benchmark_quantization_gcp.sh
+          lsm-access-strategy: ${{ inputs.lsm_access_strategy }}
+          test-name-suffix: rq-1bit
+          timeout: '25m'
       - name: Cleanup GCP resources
         if: always()
         run: ./cleanup_gcp_resources.sh
@@ -887,14 +936,23 @@ jobs:
         uses: 'google-github-actions/setup-gcloud@v3'
       - name: Run chaos test
         if: always()
-        run: ./ann_benchmark_gcp.sh
+        uses: ./.github/actions/run-chaos-test
+        with:
+          command: ./ann_benchmark_gcp.sh
+          lsm-access-strategy: ${{ inputs.lsm_access_strategy }}
+          timeout: '27m'
 
       - name: Run chaos test with PQ
         if: always()
         env:
           QUANTIZATION: pq
           REQUIRED_RECALL: 0.60
-        run: ./ann_benchmark_quantization_gcp.sh
+        uses: ./.github/actions/run-chaos-test
+        with:
+          command: ./ann_benchmark_quantization_gcp.sh
+          lsm-access-strategy: ${{ inputs.lsm_access_strategy }}
+          test-name-suffix: pq
+          timeout: '27m'
 
       - name: Cleanup GCP resources
         if: always()
@@ -940,7 +998,10 @@ jobs:
         if: always()
         env:
           QUANTIZATION: sq
-        run: ./ann_benchmark_quantization_gcp.sh
+        uses: ./.github/actions/run-chaos-test
+        with:
+          command: ./ann_benchmark_quantization_gcp.sh
+          lsm-access-strategy: ${{ inputs.lsm_access_strategy }}
       - name: Cleanup GCP resources
         if: always()
         run: ./cleanup_gcp_resources.sh
@@ -987,13 +1048,22 @@ jobs:
         env:
           QUANTIZATION: rq
           RQ_BITS: 8
-        run: ./ann_benchmark_quantization_gcp.sh
+        uses: ./.github/actions/run-chaos-test
+        with:
+          command: ./ann_benchmark_quantization_gcp.sh
+          lsm-access-strategy: ${{ inputs.lsm_access_strategy }}
+          timeout: '27m'
       - name: Run chaos test with RQ with one bit
         if: ${{ needs.newer-or-equal-than-1_33.outputs.check == 'true' }}
         env:
           QUANTIZATION: rq
           RQ_BITS: 1
-        run: ./ann_benchmark_quantization_gcp.sh
+        uses: ./.github/actions/run-chaos-test
+        with:
+          command: ./ann_benchmark_quantization_gcp.sh
+          lsm-access-strategy: ${{ inputs.lsm_access_strategy }}
+          test-name-suffix: rq-1bit
+          timeout: '27m'
       - name: Cleanup GCP resources
         if: always()
         run: ./cleanup_gcp_resources.sh
@@ -1027,7 +1097,10 @@ jobs:
       - name: Collect Workflow Telemetry
         uses: catchpoint/workflow-telemetry-action@master
       - name: Run chaos test
-        run: ./batch_import_many_classes.sh
+        uses: ./.github/actions/run-chaos-test
+        with:
+          command: ./batch_import_many_classes.sh
+          lsm-access-strategy: ${{ inputs.lsm_access_strategy }}
   upgrade-journey:
     name: Rolling updates in single-node setup from min to target version
     if: ${{ github.event.inputs.test_to_run == 'upgrade-journey' || github.event.inputs.test_to_run == '' }}
@@ -1059,7 +1132,10 @@ jobs:
       - name: Run chaos test
         env:
           GITHUB_TOKEN: ${{ github.token }}
-        run: ./upgrade_journey.sh
+        uses: ./.github/actions/run-chaos-test
+        with:
+          command: ./upgrade_journey.sh
+          lsm-access-strategy: ${{ inputs.lsm_access_strategy }}
   upgrade-journey-cluster:
     name: Rolling updates in multi-node setup from min to target version
     if: ${{ github.event.inputs.test_to_run == 'upgrade-journey-cluster' || github.event.inputs.test_to_run == '' }}
@@ -1090,7 +1166,10 @@ jobs:
       - name: Run chaos test
         env:
           GITHUB_TOKEN: ${{ github.token }}
-        run: ./upgrade_journey.sh
+        uses: ./.github/actions/run-chaos-test
+        with:
+          command: ./upgrade_journey.sh
+          lsm-access-strategy: ${{ inputs.lsm_access_strategy }}
   replicated-imports-with-chaos-killing:
     name: Replicated imports with chaos killing
     if: ${{ github.event.inputs.test_to_run == 'replicated-imports-with-chaos-killing' || github.event.inputs.test_to_run == '' }}
@@ -1115,7 +1194,10 @@ jobs:
       #- name: Setup tmate session
       #uses: mxschmitt/action-tmate@v3
       - name: Run chaos test
-        run: ./replication_importing_while_crashing.sh
+        uses: ./.github/actions/run-chaos-test
+        with:
+          command: ./replication_importing_while_crashing.sh
+          lsm-access-strategy: ${{ inputs.lsm_access_strategy }}
   replicated-imports-with-backup:
     name: Replicated imports with backup loop
     if: ${{ github.event.inputs.test_to_run == 'replicated-imports-with-backup' || github.event.inputs.test_to_run == '' }}
@@ -1138,7 +1220,10 @@ jobs:
       - name: Collect Workflow Telemetry
         uses: catchpoint/workflow-telemetry-action@master
       - name: Run chaos test
-        run: ./replication_importing_with_backup.sh
+        uses: ./.github/actions/run-chaos-test
+        with:
+          command: ./replication_importing_with_backup.sh
+          lsm-access-strategy: ${{ inputs.lsm_access_strategy }}
   replication-tunable-consistency:
     name: Replication tunable consistency
     if: ${{ github.event.inputs.test_to_run == 'replication-tunable-consistency' || github.event.inputs.test_to_run == '' }}
@@ -1161,7 +1246,10 @@ jobs:
       - name: Collect Workflow Telemetry
         uses: catchpoint/workflow-telemetry-action@master
       - name: Run chaos test
-        run: ./replication_tunable_consistency.sh
+        uses: ./.github/actions/run-chaos-test
+        with:
+          command: ./replication_tunable_consistency.sh
+          lsm-access-strategy: ${{ inputs.lsm_access_strategy }}
   counting-while-compacting:
     name: Counting while compacting
     if: ${{ github.event.inputs.test_to_run == 'counting-while-compacting' || github.event.inputs.test_to_run == '' }}
@@ -1184,7 +1272,10 @@ jobs:
       - name: Collect Workflow Telemetry
         uses: catchpoint/workflow-telemetry-action@master
       - name: Run chaos test
-        run: ./counting_while_compacting.sh
+        uses: ./.github/actions/run-chaos-test
+        with:
+          command: ./counting_while_compacting.sh
+          lsm-access-strategy: ${{ inputs.lsm_access_strategy }}
   compaction-and-cleanup:
     name: Compaction and cleanup
     if: ${{ github.event.inputs.test_to_run == 'compaction-and-cleanup' || github.event.inputs.test_to_run == '' }}
@@ -1207,7 +1298,10 @@ jobs:
       - name: Collect Workflow Telemetry
         uses: catchpoint/workflow-telemetry-action@master
       - name: Run chaos test
-        run: ./compaction_and_cleanup.sh
+        uses: ./.github/actions/run-chaos-test
+        with:
+          command: ./compaction_and_cleanup.sh
+          lsm-access-strategy: ${{ inputs.lsm_access_strategy }}
   segfault-on-batch-ref:
     name: Segfault on batch ref
     if: ${{ github.event.inputs.test_to_run == 'segfault-on-batch-ref' || github.event.inputs.test_to_run == '' }}
@@ -1230,7 +1324,10 @@ jobs:
       - name: Collect Workflow Telemetry
         uses: catchpoint/workflow-telemetry-action@master
       - name: Run chaos test
-        run: ./segfault_batch_ref.sh
+        uses: ./.github/actions/run-chaos-test
+        with:
+          command: ./segfault_batch_ref.sh
+          lsm-access-strategy: ${{ inputs.lsm_access_strategy }}
   import-with-kills:
     name: Import during constant kills/crashes
     if: ${{ github.event.inputs.test_to_run == 'import-with-kills' || github.event.inputs.test_to_run == '' }}
@@ -1253,7 +1350,10 @@ jobs:
       - name: Collect Workflow Telemetry
         uses: catchpoint/workflow-telemetry-action@master
       - name: Run chaos test
-        run: ./import_while_crashing.sh
+        uses: ./.github/actions/run-chaos-test
+        with:
+          command: ./import_while_crashing.sh
+          lsm-access-strategy: ${{ inputs.lsm_access_strategy }}
   heavy-imports-crashing:
     name: Heavy object store imports while crashing
     if: ${{ github.event.inputs.test_to_run == 'heavy-imports-crashing' || github.event.inputs.test_to_run == '' }}
@@ -1276,7 +1376,10 @@ jobs:
       - name: Collect Workflow Telemetry
         uses: catchpoint/workflow-telemetry-action@master
       - name: Run chaos test
-        run: ./import_while_crashing_no_vector.sh
+        uses: ./.github/actions/run-chaos-test
+        with:
+          command: ./import_while_crashing_no_vector.sh
+          lsm-access-strategy: ${{ inputs.lsm_access_strategy }}
   segfault-filtered-search:
     name: Segfault on filtered vector search (race with hash bucket compaction)
     runs-on: ubicloud-standard-2
@@ -1299,7 +1402,10 @@ jobs:
       - name: Collect Workflow Telemetry
         uses: catchpoint/workflow-telemetry-action@master
       - name: Run chaos test
-        run: ./segfault_filtered_vector_search.sh
+        uses: ./.github/actions/run-chaos-test
+        with:
+          command: ./segfault_filtered_vector_search.sh
+          lsm-access-strategy: ${{ inputs.lsm_access_strategy }}
   backup-restore-crud:
     name: Backup & Restore CRUD
     runs-on: ubicloud-standard-4
@@ -1322,7 +1428,10 @@ jobs:
       - name: Collect Workflow Telemetry
         uses: catchpoint/workflow-telemetry-action@master
       - name: Run chaos test
-        run: ./backup_and_restore_crud.sh
+        uses: ./.github/actions/run-chaos-test
+        with:
+          command: ./backup_and_restore_crud.sh
+          lsm-access-strategy: ${{ inputs.lsm_access_strategy }}
   backup-restore-crud-multi-node:
     name: Backup & Restore multi node CRUD
     runs-on: ubicloud-standard-4
@@ -1345,7 +1454,10 @@ jobs:
       - name: Collect Workflow Telemetry
         uses: catchpoint/workflow-telemetry-action@master
       - name: Run chaos test
-        run: ./backup_and_restore_multi_node_crud.sh
+        uses: ./.github/actions/run-chaos-test
+        with:
+          command: ./backup_and_restore_multi_node_crud.sh
+          lsm-access-strategy: ${{ inputs.lsm_access_strategy }}
   backup-restore-node-mapping:
     name: Backup & Restore 3-node with node mapping
     runs-on: ubicloud-standard-4
@@ -1363,7 +1475,11 @@ jobs:
       - name: Collect Workflow Telemetry
         uses: catchpoint/workflow-telemetry-action@master
       - name: Run chaos test
-        run: ./backup_and_restore_node_mapping.sh
+        uses: ./.github/actions/run-chaos-test
+        with:
+          command: ./backup_and_restore_node_mapping.sh
+          lsm-access-strategy: ${{ inputs.lsm_access_strategy }}
+          timeout: '0'
   backup-restore-version-compat:
     name: Backup & Restore version compatibility
     runs-on: ubicloud-standard-8
@@ -1386,7 +1502,10 @@ jobs:
       - name: Collect Workflow Telemetry
         uses: catchpoint/workflow-telemetry-action@master
       - name: Run chaos test
-        run: ./backup_and_restore_version_compatibility.sh
+        uses: ./.github/actions/run-chaos-test
+        with:
+          command: ./backup_and_restore_version_compatibility.sh
+          lsm-access-strategy: ${{ inputs.lsm_access_strategy }}
   compare-recall:
     name: Compare Recall after import to after restart
     runs-on: ubicloud-standard-2
@@ -1409,7 +1528,10 @@ jobs:
       - name: Collect Workflow Telemetry
         uses: catchpoint/workflow-telemetry-action@master
       - name: Run chaos test
-        run: ./compare_recall_after_restart.sh
+        uses: ./.github/actions/run-chaos-test
+        with:
+          command: ./compare_recall_after_restart.sh
+          lsm-access-strategy: ${{ inputs.lsm_access_strategy }}
   concurrent-read-write:
     name: Concurrent inverted index read/write
     runs-on: ubicloud-standard-2
@@ -1432,7 +1554,10 @@ jobs:
       - name: Collect Workflow Telemetry
         uses: catchpoint/workflow-telemetry-action@master
       - name: Run chaos test
-        run: ./concurrent_inverted_index_read_write.sh
+        uses: ./.github/actions/run-chaos-test
+        with:
+          command: ./concurrent_inverted_index_read_write.sh
+          lsm-access-strategy: ${{ inputs.lsm_access_strategy }}
   consecutive-create-update:
     name: Consecutive create and update operations
     runs-on: ubicloud-standard-2
@@ -1455,7 +1580,10 @@ jobs:
       - name: Collect Workflow Telemetry
         uses: catchpoint/workflow-telemetry-action@master
       - name: Run chaos test
-        run: ./consecutive_create_and_update_operations.sh
+        uses: ./.github/actions/run-chaos-test
+        with:
+          command: ./consecutive_create_and_update_operations.sh
+          lsm-access-strategy: ${{ inputs.lsm_access_strategy }}
   batch-insert-mismatch:
     name: Batch insert mismatch
     runs-on: ubicloud-standard-4
@@ -1478,7 +1606,10 @@ jobs:
       - name: Collect Workflow Telemetry
         uses: catchpoint/workflow-telemetry-action@master
       - name: Run chaos test
-        run: ./consecutive_create_and_update_operations.sh
+        uses: ./.github/actions/run-chaos-test
+        with:
+          command: ./consecutive_create_and_update_operations.sh
+          lsm-access-strategy: ${{ inputs.lsm_access_strategy }}
   rest-patch-restart:
     name: REST PATCH requests stop working after restart
     runs-on: ubicloud-standard-4
@@ -1501,7 +1632,10 @@ jobs:
       - name: Collect Workflow Telemetry
         uses: catchpoint/workflow-telemetry-action@master
       - name: Run chaos test
-        run: ./rest_patch_stops_working_after_restart.sh
+        uses: ./.github/actions/run-chaos-test
+        with:
+          command: ./rest_patch_stops_working_after_restart.sh
+          lsm-access-strategy: ${{ inputs.lsm_access_strategy }}
   delete-recreate-updates:
     name: Delete and recreate class with frequent updates
     runs-on: ubicloud-standard-4
@@ -1524,7 +1658,10 @@ jobs:
       - name: Collect Workflow Telemetry
         uses: catchpoint/workflow-telemetry-action@master
       - name: Run chaos test
-        run: ./delete_and_recreate_class.sh
+        uses: ./.github/actions/run-chaos-test
+        with:
+          command: ./delete_and_recreate_class.sh
+          lsm-access-strategy: ${{ inputs.lsm_access_strategy }}
   deletes-with_node-out-of-sync:
     # Fixed in 1.24.18 and 1.25.4
     name: Delete objects with CL ONE on a node out of sync
@@ -1543,7 +1680,10 @@ jobs:
       - name: Collect Workflow Telemetry
         uses: catchpoint/workflow-telemetry-action@master
       - name: Run chaos test
-        run: ./deletes_with_node_out_of_sync.sh
+        uses: ./.github/actions/run-chaos-test
+        with:
+          command: ./deletes_with_node_out_of_sync.sh
+          lsm-access-strategy: ${{ inputs.lsm_access_strategy }}
   geo-crash:
     name: Preventing crashing of geo properties during HNSW maintenance cycles
     if: ${{ github.event.inputs.test_to_run == 'geo-crash' || github.event.inputs.test_to_run == '' }}
@@ -1567,7 +1707,10 @@ jobs:
       - name: Collect Workflow Telemetry
         uses: catchpoint/workflow-telemetry-action@master
       - name: Run chaos test
-        run: ./geo_crash.sh
+        uses: ./.github/actions/run-chaos-test
+        with:
+          command: ./geo_crash.sh
+          lsm-access-strategy: ${{ inputs.lsm_access_strategy }}
   compaction-roaringset:
     name: Preventing panic on compaction of roaringsets
     runs-on: ubicloud-standard-4
@@ -1590,7 +1733,10 @@ jobs:
       - name: Collect Workflow Telemetry
         uses: catchpoint/workflow-telemetry-action@master
       - name: Run chaos test
-        run: ./compaction_roaringset.sh
+        uses: ./.github/actions/run-chaos-test
+        with:
+          command: ./compaction_roaringset.sh
+          lsm-access-strategy: ${{ inputs.lsm_access_strategy }}
   multi-node-references:
     name: Large batches with many cross-refs on a multi-node cluster
     runs-on: ubicloud-standard-4
@@ -1613,7 +1759,10 @@ jobs:
       - name: Collect Workflow Telemetry
         uses: catchpoint/workflow-telemetry-action@master
       - name: Run chaos test
-        run: ./multi_node_ref_imports.sh
+        uses: ./.github/actions/run-chaos-test
+        with:
+          command: ./multi_node_ref_imports.sh
+          lsm-access-strategy: ${{ inputs.lsm_access_strategy }}
   multi-tenancy-concurrent-imports:
     name: Concurrent clients importing into multi-node cluster
     if: ${{ github.event.inputs.test_to_run == 'multi-tenancy-concurrent-imports' || github.event.inputs.test_to_run == '' }}
@@ -1636,7 +1785,10 @@ jobs:
       - name: Collect Workflow Telemetry
         uses: catchpoint/workflow-telemetry-action@master
       - name: Run chaos test
-        run: ./multi_tenancy_concurrent_importing.sh
+        uses: ./.github/actions/run-chaos-test
+        with:
+          command: ./multi_tenancy_concurrent_importing.sh
+          lsm-access-strategy: ${{ inputs.lsm_access_strategy }}
   multi_tenancy_activate_deactivate_v1_24:
     needs: [equal-to-1_24]
     if: ${{ (needs.equal-to-1_24.outputs.check == 'true') && ( github.event.inputs.test_to_run == 'multi_tenancy_activate_deactivate_v1_24' || github.event.inputs.test_to_run == '') }}
@@ -1660,7 +1812,10 @@ jobs:
       - name: Collect Workflow Telemetry
         uses: catchpoint/workflow-telemetry-action@master
       - name: Run chaos test
-        run: ./multi_tenancy_activate_deactivate_v1_24.sh
+        uses: ./.github/actions/run-chaos-test
+        with:
+          command: ./multi_tenancy_activate_deactivate_v1_24.sh
+          lsm-access-strategy: ${{ inputs.lsm_access_strategy }}
   multi_tenancy_activate_deactivate:
     needs: [newer-or-equal-than-1_25]
     if: ${{ (needs.newer-or-equal-than-1_25.outputs.check ) && ( github.event.inputs.test_to_run == 'multi_tenancy_activate_deactivate' || github.event.inputs.test_to_run == '') }}
@@ -1684,7 +1839,10 @@ jobs:
       - name: Collect Workflow Telemetry
         uses: catchpoint/workflow-telemetry-action@master
       - name: Run chaos test
-        run: ./multi_tenancy_activate_deactivate.sh
+        uses: ./.github/actions/run-chaos-test
+        with:
+          command: ./multi_tenancy_activate_deactivate.sh
+          lsm-access-strategy: ${{ inputs.lsm_access_strategy }}
   goroutine_leak_class_delete:
     name: Check for degraded performance from goroutine leak on class delete
     runs-on: ubuntu-latest
@@ -1707,7 +1865,10 @@ jobs:
       - name: Collect Workflow Telemetry
         uses: catchpoint/workflow-telemetry-action@master
       - name: Run chaos test
-        run: ./goroutine_leak_on_class_delete.sh
+        uses: ./.github/actions/run-chaos-test
+        with:
+          command: ./goroutine_leak_on_class_delete.sh
+          lsm-access-strategy: ${{ inputs.lsm_access_strategy }}
   bm25_corruption:
     name: Validate that the BM25 (and other indexes) index does not corrupt when crashes occur during batch delete
     runs-on: ubicloud-standard-2
@@ -1730,7 +1891,10 @@ jobs:
       - name: Collect Workflow Telemetry
         uses: catchpoint/workflow-telemetry-action@master
       - name: Run chaos test
-        run: ./bm25_corruption.sh
+        uses: ./.github/actions/run-chaos-test
+        with:
+          command: ./bm25_corruption.sh
+          lsm-access-strategy: ${{ inputs.lsm_access_strategy }}
   backup_and_flush:
     # https://github.com/weaviate/weaviate/issues/4418
     name: Test that flushing is reestablished after a backup is performed
@@ -1754,7 +1918,10 @@ jobs:
       - name: Collect Workflow Telemetry
         uses: catchpoint/workflow-telemetry-action@master
       - name: Run chaos test
-        run: ./backup_and_flush.sh
+        uses: ./.github/actions/run-chaos-test
+        with:
+          command: ./backup_and_flush.sh
+          lsm-access-strategy: ${{ inputs.lsm_access_strategy }}
   backup_and_restore_out_of_sync:
     # https://github.com/weaviate/weaviate/pull/4541
     name: Test that restoring a backup without data presence ensures schema consistency across nodes
@@ -1778,7 +1945,10 @@ jobs:
       - name: Collect Workflow Telemetry
         uses: catchpoint/workflow-telemetry-action@master
       - name: Run chaos test
-        run: ./backup_and_restore_multi_node_out_of_sync.sh
+        uses: ./.github/actions/run-chaos-test
+        with:
+          command: ./backup_and_restore_multi_node_out_of_sync.sh
+          lsm-access-strategy: ${{ inputs.lsm_access_strategy }}
   # Commented only because this chaos pipeline was able to interrupt save operation
   # just in the middle of it being performed and since Weaviate doesn't have a transaction
   # mechanism implemented then this was causing an error which is a different error then
@@ -1820,7 +1990,10 @@ jobs:
       - name: Collect Workflow Telemetry
         uses: catchpoint/workflow-telemetry-action@master
       - name: Run chaos test
-        run: ./upgrade_single_node_journey.sh
+        uses: ./.github/actions/run-chaos-test
+        with:
+          command: ./upgrade_single_node_journey.sh
+          lsm-access-strategy: ${{ inputs.lsm_access_strategy }}
   upgrade-journey-raft:
     needs: [newer-or-equal-than-1_25, older-than-1_30]
     if: ${{ (needs.newer-or-equal-than-1_25.outputs.check == 'true') && ((needs.older-than-1_30.outputs.check == 'true')) && ( github.event.inputs.test_to_run == 'upgrade-journey-raft' || github.event.inputs.test_to_run == '')}}
@@ -1925,6 +2098,13 @@ jobs:
           path: |
             apps/upgrade-journey-raft/logs/
             /tmp/weaviate*
+      - name: Report job result as JUnit
+        if: always()
+        uses: ./.github/actions/report-job-junit
+        with:
+          job-status: ${{ job.status }}
+          lsm-access-strategy: ${{ inputs.lsm_access_strategy }}
+          github-token: ${{ github.token }}
   upgrade-journey-raft-1_30:
     needs: [newer-or-equal-than-1_30]
     if: ${{ (needs.newer-or-equal-than-1_30.outputs.check == 'true') && ( github.event.inputs.test_to_run == 'upgrade-journey-raft-1_30' || github.event.inputs.test_to_run == '')}}
@@ -2043,6 +2223,13 @@ jobs:
           path: |
             apps/upgrade-journey-raft/logs/
             /tmp/weaviate*
+      - name: Report job result as JUnit
+        if: always()
+        uses: ./.github/actions/report-job-junit
+        with:
+          job-status: ${{ job.status }}
+          lsm-access-strategy: ${{ inputs.lsm_access_strategy }}
+          github-token: ${{ github.token }}
   upgrade-journey-raft-metadata-only-voters:
     needs: [newer-or-equal-than-1_25]
     if: ${{ (needs.newer-or-equal-than-1_25.outputs.check == 'true') && ( github.event.inputs.test_to_run == 'upgrade-journey-raft-metadata-only-voters' || github.event.inputs.test_to_run == '') }}
@@ -2112,6 +2299,13 @@ jobs:
         with:
           name: upgrade-journey-raft-metadata-only-voters-${{ inputs.lsm_access_strategy }}-logs
           path: apps/upgrade-journey-raft/logs/
+      - name: Report job result as JUnit
+        if: always()
+        uses: ./.github/actions/report-job-junit
+        with:
+          job-status: ${{ job.status }}
+          lsm-access-strategy: ${{ inputs.lsm_access_strategy }}
+          github-token: ${{ github.token }}
   rbac-upgrade-journey:
     needs: [real-version-in-tag, newer-or-equal-than-1_30]
     if: ${{ (needs.newer-or-equal-than-1_30.outputs.check == 'true') && ( github.event.inputs.test_to_run == 'rbac-upgrade-journey' || github.event.inputs.test_to_run == '')}}
@@ -2324,6 +2518,13 @@ jobs:
           path: |
             apps/upgrade-journey-raft/logs/
             /tmp/weaviate*
+      - name: Report job result as JUnit
+        if: always()
+        uses: ./.github/actions/report-job-junit
+        with:
+          job-status: ${{ job.status }}
+          lsm-access-strategy: ${{ inputs.lsm_access_strategy }}
+          github-token: ${{ github.token }}
   async-repair:
     # CONTEXT: https://github.com/weaviate/weaviate/issues/5229
     needs: [newer-or-equal-than-1_26]
@@ -2348,7 +2549,10 @@ jobs:
       - name: Collect Workflow Telemetry
         uses: catchpoint/workflow-telemetry-action@master
       - name: Run chaos test
-        run: ./async_repair.sh
+        uses: ./.github/actions/run-chaos-test
+        with:
+          command: ./async_repair.sh
+          lsm-access-strategy: ${{ inputs.lsm_access_strategy }}
   update-stability:
     name: Recall Stability on object updates
     runs-on: ubicloud-standard-2
@@ -2379,7 +2583,10 @@ jobs:
       - name: Collect Workflow Telemetry
         uses: catchpoint/workflow-telemetry-action@master
       - name: Run chaos test
-        run: ./update_stability.sh
+        uses: ./.github/actions/run-chaos-test
+        with:
+          command: ./update_stability.sh
+          lsm-access-strategy: ${{ inputs.lsm_access_strategy }}
   debug-reindexing-endpoint-journey-tests:
     needs: [newer-or-equal-than-1_24]
     if: ${{ (needs.newer-or-equal-than-1_24.outputs.check == 'true') && (github.event.inputs.test_to_run == 'debug-reindexing-endpoint-journey-tests' || github.event.inputs.test_to_run == '' )}}
@@ -2402,8 +2609,11 @@ jobs:
         with:
           go-version: '1.22'
       - name: Run reindexing chaos tests
-        run: |
-          ./debug-reindexing.sh
+        uses: ./.github/actions/run-chaos-test
+        with:
+          command: |
+            ./debug-reindexing.sh
+          lsm-access-strategy: ${{ inputs.lsm_access_strategy }}
   upgrade-journey-object-nested-properties:
     needs: [newer-or-equal-than-1_26]
     if: ${{ (needs.newer-or-equal-than-1_26.outputs.check == 'true') && (github.event.inputs.test_to_run == 'upgrade-journey-object-nested-properties' || github.event.inputs.test_to_run == '' )}}
@@ -2426,8 +2636,11 @@ jobs:
         with:
           go-version: '1.22'
       - name: Run upgrade journey object nested properties tests
-        run: |
-          ./upgrade_journey_object_nested_properties.sh
+        uses: ./.github/actions/run-chaos-test
+        with:
+          command: |
+            ./upgrade_journey_object_nested_properties.sh
+          lsm-access-strategy: ${{ inputs.lsm_access_strategy }}
   compaction-optimization:
     needs: [newer-or-equal-than-1_24]
     if: ${{ (needs.newer-or-equal-than-1_24.outputs.check == 'true') && (github.event.inputs.test_to_run == 'compaction-optimization' || github.event.inputs.test_to_run == '' ) }}
@@ -2450,8 +2663,11 @@ jobs:
         with:
           go-version: '1.22'
       - name: Run compaction-optimization chaos tests
-        run: |
-          ./compaction_optimization.sh
+        uses: ./.github/actions/run-chaos-test
+        with:
+          command: |
+            ./compaction_optimization.sh
+          lsm-access-strategy: ${{ inputs.lsm_access_strategy }}
   downgrade-journey-raft-schema:
     needs: [newer-or-equal-than-1_28]
     name: Downgrade journey Raft schema - single node
@@ -2478,7 +2694,10 @@ jobs:
       - name: Run chaos test
         env:
           GITHUB_TOKEN: ${{ github.token }}
-        run: ./downgrade_journey_raft_schema.sh
+        uses: ./.github/actions/run-chaos-test
+        with:
+          command: ./downgrade_journey_raft_schema.sh
+          lsm-access-strategy: ${{ inputs.lsm_access_strategy }}
   downgrade-journey-raft-schema-cluster:
     needs: [newer-or-equal-than-1_28]
     name: Downgrade journey Raft schema - cluster
@@ -2505,7 +2724,10 @@ jobs:
       - name: Run chaos test
         env:
           GITHUB_TOKEN: ${{ github.token }}
-        run: ./downgrade_journey_raft_schema.sh
+        uses: ./.github/actions/run-chaos-test
+        with:
+          command: ./downgrade_journey_raft_schema.sh
+          lsm-access-strategy: ${{ inputs.lsm_access_strategy }}
 
   tombstones-cleanup-while-crash:
     needs: [newer-or-equal-than-1_28]
@@ -2529,8 +2751,11 @@ jobs:
         with:
           go-version: '1.22'
       - name: Run tombstones-cleanup-while-crash chaos tests
-        run: |
-          ./tombstones_cleanup_while_crash.sh
+        uses: ./.github/actions/run-chaos-test
+        with:
+          command: |
+            ./tombstones_cleanup_while_crash.sh
+          lsm-access-strategy: ${{ inputs.lsm_access_strategy }}
 
   condensing-while-crash:
     needs: [newer-or-equal-than-1_28]
@@ -2554,8 +2779,11 @@ jobs:
         with:
           go-version: '1.22'
       - name: Run condensing-while-crash chaos tests
-        run: |
-          ./condensing_while_crash.sh
+        uses: ./.github/actions/run-chaos-test
+        with:
+          command: |
+            ./condensing_while_crash.sh
+          lsm-access-strategy: ${{ inputs.lsm_access_strategy }}
 
   hnsw-snapshotting-while-crash:
     needs: [newer-or-equal-than-1_31]
@@ -2579,8 +2807,11 @@ jobs:
         with:
           go-version: '1.22'
       - name: Run hnsw-snapshotting-while-crash chaos tests
-        run: |
-          ./hnsw_snapshotting_while_crash.sh
+        uses: ./.github/actions/run-chaos-test
+        with:
+          command: |
+            ./hnsw_snapshotting_while_crash.sh
+          lsm-access-strategy: ${{ inputs.lsm_access_strategy }}
   
   server-side-batching-with-rolling-restart-without-async-indexing:
     needs: [equal-to-1_36_rc]
@@ -2611,7 +2842,10 @@ jobs:
           weaviate-version: ${{env.WEAVIATE_VERSION}}
           values-inline: '--set env.PERSISTENCE_LSM_ACCESS_STRATEGY=${{env.PERSISTENCE_LSM_ACCESS_STRATEGY}} --set env.ASYNC_INDEXING=${{env.ASYNC_INDEXING}}'
       - name: Run chaos test
-        run: ./server_side_batching_with_rolling_restart.sh
+        uses: ./.github/actions/run-chaos-test
+        with:
+          command: ./server_side_batching_with_rolling_restart.sh
+          lsm-access-strategy: ${{ inputs.lsm_access_strategy }}
 
   server-side-batching-with-rolling-restart-with-async-indexing:
     needs: [equal-to-1_36_rc]
@@ -2638,7 +2872,10 @@ jobs:
           weaviate-version: ${{env.WEAVIATE_VERSION}}
           values-inline: '--set env.PERSISTENCE_LSM_ACCESS_STRATEGY=${{env.PERSISTENCE_LSM_ACCESS_STRATEGY}} --set env.ASYNC_INDEXING=${{env.ASYNC_INDEXING}}'
       - name: Run chaos test
-        run: ./server_side_batching_with_rolling_restart.sh
+        uses: ./.github/actions/run-chaos-test
+        with:
+          command: ./server_side_batching_with_rolling_restart.sh
+          lsm-access-strategy: ${{ inputs.lsm_access_strategy }}
 
   module-conflicting-vectorizer-settings:
     needs: [newer-or-equal-than-1_33]
@@ -2661,9 +2898,12 @@ jobs:
         env:
           WEAVIATE_VERSION: ${{ inputs.weaviate_version }}
           PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
-        run: |
-          cd apps/module-conflicting-vectorizer-settings
-          bash ./test.sh
+        uses: ./.github/actions/run-chaos-test
+        with:
+          command: |
+            cd apps/module-conflicting-vectorizer-settings
+            bash ./test.sh
+          lsm-access-strategy: ${{ inputs.lsm_access_strategy }}
       - name: Archive logs
         if: always()
         uses: actions/upload-artifact@v5
@@ -2704,7 +2944,10 @@ jobs:
           modules: 'text2vec-model2vec'
           values-inline: '--set env.PERSISTENCE_LSM_ACCESS_STRATEGY=${{env.PERSISTENCE_LSM_ACCESS_STRATEGY}}'
       - name: Run alter schema drop property index tests
-        run: apps/alter_schema_operations/alter_schema_drop_property_index.sh
+        uses: ./.github/actions/run-chaos-test
+        with:
+          command: apps/alter_schema_operations/alter_schema_drop_property_index.sh
+          lsm-access-strategy: ${{ inputs.lsm_access_strategy }}
       - name: Archive logs
         if: always()
         uses: actions/upload-artifact@v5
@@ -2743,7 +2986,10 @@ jobs:
           modules: 'text2vec-model2vec'
           values-inline: '--set env.PERSISTENCE_LSM_ACCESS_STRATEGY=${{env.PERSISTENCE_LSM_ACCESS_STRATEGY}} --set env.ENABLE_EXPERIMENTAL_ALTER_SCHEMA_DROP_VECTOR_INDEX_ENDPOINT=true'
       - name: Run alter schema drop vector index tests
-        run: apps/alter_schema_operations/alter_schema_drop_vector_index.sh
+        uses: ./.github/actions/run-chaos-test
+        with:
+          command: apps/alter_schema_operations/alter_schema_drop_vector_index.sh
+          lsm-access-strategy: ${{ inputs.lsm_access_strategy }}
       - name: Archive logs
         if: always()
         uses: actions/upload-artifact@v5
@@ -2801,9 +3047,13 @@ jobs:
         with:
           action: start
       - name: Weaviate - create collections and ingest data in the background
-        run: |
-          cd apps/restart-highly-available-qps-benchmark
-          python3 ingest_and_benchmark_qps.py rolling-restart
+        uses: ./.github/actions/run-chaos-test
+        with:
+          command: |
+            cd apps/restart-highly-available-qps-benchmark
+            python3 ingest_and_benchmark_qps.py rolling-restart
+          lsm-access-strategy: ${{ inputs.lsm_access_strategy }}
+          timeout: '50m'
       - name: Stop stern
         if: always()
         uses: weaviate/github-common-actions/.github/actions/capture-logs@main
@@ -2819,13 +3069,18 @@ jobs:
             /tmp/weaviate*
       - name: Check for panics in logs
         if: always()
-        run: |
-          if grep -iE "panic:|runtime error:|goroutine.*\[running\]" /tmp/weaviate_pods.log; then
-            echo "::error::Found panic in weaviate logs"
-            echo "Panic context:"
-            grep -A 20 -iE "panic:|runtime error:|goroutine.*\[running\]" /tmp/weaviate_pods.log
-            exit 1
-          fi
+        uses: ./.github/actions/run-chaos-test
+        with:
+          command: |
+            if grep -iE "panic:|runtime error:|goroutine.*\[running\]" /tmp/weaviate_pods.log; then
+              echo "::error::Found panic in weaviate logs"
+              echo "Panic context:"
+              grep -A 20 -iE "panic:|runtime error:|goroutine.*\[running\]" /tmp/weaviate_pods.log
+              exit 1
+            fi
+          lsm-access-strategy: ${{ inputs.lsm_access_strategy }}
+          test-name-suffix: panic-check
+          timeout: '5m'
   single-pod-restart-highly-available-qps-benchmark:
     needs: [newer-or-equal-than-1_31, newer-or-equal-than-1_36]
     if: ${{ (needs.newer-or-equal-than-1_31.outputs.check == 'true') && ( github.event.inputs.test_to_run == 'single-pod-restart-highly-available-qps-benchmark' || github.event.inputs.test_to_run == '')}}
@@ -2874,9 +3129,13 @@ jobs:
         with:
           action: start
       - name: Weaviate - create collections and ingest data in the background
-        run: |
-          cd apps/restart-highly-available-qps-benchmark
-          python3 ingest_and_benchmark_qps.py single-pod-restart
+        uses: ./.github/actions/run-chaos-test
+        with:
+          command: |
+            cd apps/restart-highly-available-qps-benchmark
+            python3 ingest_and_benchmark_qps.py single-pod-restart
+          lsm-access-strategy: ${{ inputs.lsm_access_strategy }}
+          timeout: '50m'
       - name: Stop stern
         if: always()
         uses: weaviate/github-common-actions/.github/actions/capture-logs@main
@@ -2892,10 +3151,15 @@ jobs:
             /tmp/weaviate*
       - name: Check for panics in logs
         if: always()
-        run: |
-          if grep -iE "panic:|runtime error:|goroutine.*\[running\]" /tmp/weaviate_pods.log; then
-            echo "::error::Found panic in weaviate logs"
-            echo "Panic context:"
-            grep -A 20 -iE "panic:|runtime error:|goroutine.*\[running\]" /tmp/weaviate_pods.log
-            exit 1
-          fi
+        uses: ./.github/actions/run-chaos-test
+        with:
+          command: |
+            if grep -iE "panic:|runtime error:|goroutine.*\[running\]" /tmp/weaviate_pods.log; then
+              echo "::error::Found panic in weaviate logs"
+              echo "Panic context:"
+              grep -A 20 -iE "panic:|runtime error:|goroutine.*\[running\]" /tmp/weaviate_pods.log
+              exit 1
+            fi
+          lsm-access-strategy: ${{ inputs.lsm_access_strategy }}
+          test-name-suffix: panic-check
+          timeout: '5m'

--- a/ann_benchmark_gcp.sh
+++ b/ann_benchmark_gcp.sh
@@ -32,7 +32,7 @@ function cleanup {
   echo "Running cleanup via cleanup_gcp_resources.sh..."
   bash ./cleanup_gcp_resources.sh
 }
-trap cleanup EXIT
+trap cleanup EXIT SIGINT SIGTERM ERR
 
 # Busy loop to wait for SSH to be ready with a timeout of 5 minutes
 echo "Waiting for SSH to be ready..."

--- a/ann_benchmark_quantization_gcp.sh
+++ b/ann_benchmark_quantization_gcp.sh
@@ -31,7 +31,7 @@ function cleanup {
   echo "Running cleanup via cleanup_gcp_resources.sh..."
   bash ./cleanup_gcp_resources.sh
 }
-trap cleanup EXIT
+trap cleanup EXIT SIGINT SIGTERM ERR
 
 # Busy loop to wait for SSH to be ready with a timeout of 5 minutes
 echo "Waiting for SSH to be ready..."

--- a/common.sh
+++ b/common.sh
@@ -142,12 +142,17 @@ _LOGGED_DIAGNOSTICS=0
 function run_failure_diagnostics() {
   if [[ $_LOGGED_DIAGNOSTICS -eq 0 ]]; then
     _LOGGED_DIAGNOSTICS=1
+    # machine-readable marker consumed by .github/scripts/chaos_junit.py to
+    # separate the test's own output (the failure cause) from this dump
+    echo "===CHAOS-DIAGNOSTICS-BEGIN==="
     logs
     report_container_state
   fi
 }
 
-trap 'run_failure_diagnostics; shutdown; exit 1' SIGINT ERR
+# SIGTERM is what the CI wrapper's soft timeout sends; without trapping it,
+# bash would skip the EXIT trap and leave containers + data dirs behind
+trap 'run_failure_diagnostics; shutdown; exit 1' SIGINT SIGTERM ERR
 trap 'exit_code=$?; if [[ $exit_code -ne 0 ]]; then run_failure_diagnostics; fi; shutdown' EXIT
 
 

--- a/debug-reindexing.sh
+++ b/debug-reindexing.sh
@@ -22,7 +22,7 @@ function shutdown() {
   docker compose -f apps/debug-reindexing-endpoint/docker-compose.yml down --remove-orphans
   sudo rm -rf apps/weaviate/data* || true
 }
-trap 'shutdown; exit 1' SIGINT ERR
+trap 'shutdown; exit 1' SIGINT SIGTERM ERR
 
 echo "Starting Weaviate..."
 docker compose -f apps/debug-reindexing-endpoint/docker-compose.yml up -d \


### PR DESCRIPTION
## Motivation

The chaos-engineering suite is a collection of ad-hoc shell/python/go tests with no machine-readable output, so our test-reporter tool (which tracks CI results and links back to job URLs) has no way to ingest them — unlike the e2e suite, where pytest emits a `junit.xml` for free. This PR makes every chaos test job produce a standards-compliant JUnit `test-results.xml` so the reporter can consume it.

**This PR is generation only.** The `weaviate/weaviate-test-reporter` step is a deliberate follow-up: the reporter derives the run/job URLs from its own runtime and must run *inside* each job, which is exactly why the junit file is generated per-job here rather than aggregated at the end.

## Design

Generation is **per matrix job** (each of ~70 jobs runs on its own runner, twice — once per `lsm_access_strategy`), and each job writes one `test-results.xml` with a single `<testsuite name="chaos-mmap">` / `chaos-pread`, mirroring how pytest hands the e2e repo its file. `classname` carries the strategy so the reporter keeps the two legs distinct; `name` is the job key (the same string as the `test_to_run` input), so results link back to a re-runnable test.

Three new pieces:

- **`.github/actions/run-chaos-test`** — wraps single-command jobs (~66 of them): tees output to a log, applies a soft `timeout` kept below the job-level `timeout-minutes` (so a hung test still produces a result instead of being hard-killed with nothing), records a `<testcase>`, uploads a `junit-<job>-<strategy>` artifact, and re-exits with the command's original code. Commands are passed via an env var (`bash -ec`), preserving the previous fail-fast shell semantics.
- **`.github/actions/report-job-junit`** — for the 4 multi-step "journey" jobs, runs as the last `if: always()` step: reads `job.status`, and on failure downloads the job's own log via the GitHub API mid-run (the failed step has already completed) to extract the failing step's culprit.
- **`.github/scripts/chaos_junit.py`** — stdlib-only JUnit writer + failure-culprit extractor. Recognizes Python tracebacks (including chained `raise ... from`), Go panics/`--- FAIL`, and docker-build errors, and cuts away the container-log dump that `common.sh`'s failure trap prints *after* the real error, so the `<failure>` body carries the cause. Validated against four real historical failures (rbac assertion, tombstone validation, docker 502, k8s snapshot check).

`common.sh` now traps `SIGTERM` (what the soft timeout sends) so diagnostics + teardown still run, and emits an explicit `===CHAOS-DIAGNOSTICS-BEGIN===` marker the extractor keys on. The GCP ann-benchmark scripts and `debug-reindexing.sh` got the same trap alignment (`ann_benchmark_quantization_aws.sh` already had it).

## Safety

Reporting can never change a job's pass/fail: the record step is warn-only (`|| echo ::warning`), a corrupt `test-results.xml` is quarantined rather than raised, and both artifact uploads use `continue-on-error`.

## Behavioral notes for reviewers

- **Local runs:** the new `SIGTERM` trap means a `kill <pid>` of a chaos script now runs `shutdown()` (which force-removes all docker containers on the host — same blast radius the existing `SIGINT`/`ERR` traps already had). Correct for ephemeral CI runners; worth knowing if you run these locally.
- The 6 jobs that wrap two commands under one 60-min budget got explicit per-step `timeout` values sized from a recent green run so the second command's soft timeout can still fire.

## Verification

Local: extractor validated against 4 real failed job logs; wrapper pass/fail/timeout/multi-line-fail-fast simulation; round-trip through the reporter's own `parse_junit_file`; `report-job` download+redirect+extract against a live failed run; corrupt-file recovery; 33 MB log bounded to <1s; `black 26.1.0` + `ruff` clean; `actionlint` shows only pre-existing findings. This PR run exercises the real matrix end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)