### PR TITLE
feat(ns-grad): add namespace-graduation e2e test (backup/restore + rf scale-out)

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -266,6 +266,20 @@ jobs:
           first: ${{ needs.real-version-in-tag.outputs.real_version }}
           second: "1.37.0"
           operator: ">="
+  newer-or-equal-than-1_38:
+    name: "Check if the version is newer than 1.38"
+    needs: real-version-in-tag
+    runs-on: ubicloud-standard-2
+    outputs:
+      check: ${{ steps.semver_compare.outputs.result }}
+    steps:
+      - name: Semver Compare
+        id: semver_compare
+        uses: fabriziocacicia/semver-compare-action@v0.2.0
+        with:
+          first: ${{ needs.real-version-in-tag.outputs.real_version }}
+          second: "1.38.0"
+          operator: ">="
   filter-memory-leak:
     name: Filter (cache) memory leak when querying while importing
     if: ${{ github.event.inputs.test_to_run == 'filter-memory-leak' || github.event.inputs.test_to_run == '' }}
@@ -1393,6 +1407,25 @@ jobs:
         uses: catchpoint/workflow-telemetry-action@master
       - name: Run chaos test
         run: ./backup_and_restore_version_compatibility.sh
+  namespace-graduation:
+    name: Namespace graduation (backup/restore migration + rf=1->3 scale-out)
+    runs-on: ubicloud-standard-8
+    needs: [newer-or-equal-than-1_38]
+    # The namespace compose files do not read PERSISTENCE_LSM_ACCESS_STRATEGY, so the two matrix
+    # legs (mmap, pread) would provision identical clusters. Run only the pread leg.
+    if: ${{ (needs.newer-or-equal-than-1_38.outputs.check == 'true') && (inputs.lsm_access_strategy == 'pread') && (github.event.inputs.test_to_run == 'namespace-graduation' || github.event.inputs.test_to_run == '') }}
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v5
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{secrets.DOCKER_USERNAME}}
+          password: ${{secrets.DOCKER_PASSWORD}}
+      - name: Collect Workflow Telemetry
+        uses: catchpoint/workflow-telemetry-action@master
+      - name: Run chaos test
+        run: ./namespace_graduation.sh
   compare-recall:
     name: Compare Recall after import to after restart
     runs-on: ubicloud-standard-2

--- a/apps/namespace-graduation/Dockerfile
+++ b/apps/namespace-graduation/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3.13-slim-bullseye
+
+WORKDIR /workdir
+ENV PYTHONUNBUFFERED=1
+
+COPY requirements.txt .
+RUN pip3 install -r requirements.txt
+
+COPY *.py ./

--- a/apps/namespace-graduation/assertions.py
+++ b/apps/namespace-graduation/assertions.py
@@ -1,0 +1,466 @@
+"""The journey's verdict. Every assertion collects failures and never raises."""
+
+import asyncio
+import time
+from dataclasses import dataclass, field
+from typing import Any
+
+from loguru import logger
+
+import seed as seedmod
+import wvclient
+from config import Config
+from load import NeighbourLoad
+from model import ExpectedObject, ExpectedSet, normalise_vectors, vectors_equal
+from restapi import Rest, dynamic_user_ids, poll
+from seed import CAPABILITY_NARROW, SourceState
+
+# usecases/auth/authorization/types.go:233-238
+BUILT_IN_ROLES = frozenset({"viewer", "admin", "root", "read-only"})
+
+
+@dataclass
+class Failures:
+    entries: list[tuple[str, str]] = field(default_factory=list)
+
+    def add(self, assertion: str, detail: str) -> None:
+        logger.error(f"FAIL [{assertion}] {detail}")
+        self.entries.append((assertion, detail))
+
+    def __bool__(self) -> bool:
+        return bool(self.entries)
+
+    def render(self) -> str:
+        return "\n".join(f"  [{assertion}] {detail}" for assertion, detail in self.entries)
+
+
+def _not_quiescent(f: Failures, assertion: str, load: NeighbourLoad) -> bool:
+    if load.is_quiescent():
+        return False
+    f.add(assertion, "neighbour load is still running; a model comparison here would be a race")
+    return True
+
+
+async def assert_migrated_data_per_replica(
+    cfg: Config, f: Failures, root: Rest, state: SourceState, load: NeighbourLoad
+) -> None:
+    """Every expected object is present like-for-like on every one of the three replicas."""
+    assertion = "migrated-data-per-replica"
+    if _not_quiescent(f, assertion, load):
+        return
+    # Each collection is swept inside its own guard: one collection's transport failure must not
+    # leave the rest of the migration unverified.
+    for seeded in state.graduating.collections:
+        class_name = seeded.short_name
+        try:
+            if not await root.class_exists(class_name):
+                f.add(assertion, f"migrated collection {class_name} is absent from the target")
+                continue
+            nodes = await _replica_nodes(cfg, f, root, class_name, assertion)
+            if nodes is None:
+                continue
+            await _sweep_replicas(cfg, f, root, class_name, nodes, seeded.expected, assertion)
+        except Exception as exc:
+            f.add(assertion, f"{class_name} raised {exc!r}")
+
+
+async def _replica_nodes(
+    cfg: Config, f: Failures, root: Rest, class_name: str, assertion: str
+) -> list[str] | None:
+    shards = (await root.sharding_state(class_name)).get("shards") or []
+    if not shards:
+        f.add(assertion, f"{class_name} reports no shards on the target")
+        return None
+    under_replicated = {
+        shard.get("shard"): len(shard.get("replicas") or [])
+        for shard in shards
+        if len(shard.get("replicas") or []) != cfg.target_replication_factor
+    }
+    if under_replicated:
+        f.add(
+            assertion,
+            f"{class_name} shards not at rf={cfg.target_replication_factor}: {under_replicated}",
+        )
+        return None
+    nodes = sorted({node for shard in shards for node in shard.get("replicas") or []})
+    # The per-object sweep assumes every node hosts every shard, which holds for rf=3 on 3 nodes
+    # and nowhere else.
+    if len(nodes) != cfg.target_replication_factor:
+        f.add(
+            assertion,
+            f"{class_name} replicas span {len(nodes)} nodes ({nodes}), "
+            f"expected exactly {cfg.target_replication_factor}",
+        )
+        return None
+    return nodes
+
+
+async def _sweep_replicas(
+    cfg: Config,
+    f: Failures,
+    root: Rest,
+    class_name: str,
+    nodes: list[str],
+    expected: ExpectedSet,
+    assertion: str,
+) -> None:
+    """One budget for the whole collection sweep, not per object.
+
+    Unresolved ids are retried in later passes; when the budget expires every still-unresolved id is
+    reported at once. A per-object deadline would multiply into hours at the default sizing.
+    """
+    snapshot = expected.snapshot()
+    deadline = time.monotonic() + cfg.per_replica_sweep_timeout_s
+    if not snapshot:
+        # An empty model would make this assertion pass over nothing.
+        f.add(assertion, f"{class_name} has an empty expected set; there is nothing to verify")
+        return
+    semaphore = asyncio.Semaphore(cfg.per_replica_sweep_concurrency)
+    pending = [(node, uuid) for node in nodes for uuid in snapshot]
+
+    async def check(node: str, uuid: str) -> tuple[tuple[str, str], str | None]:
+        async with semaphore:
+            response = await root.object_on_node(class_name, uuid, node)
+        if response.status_code == 404:
+            return (node, uuid), "absent"
+        payload = response.json()
+        want = snapshot[uuid]
+        actual_properties = payload.get("properties") or {}
+        # Two-sided: an extra property on a restored object is as much a corruption as a missing one.
+        extra = sorted(set(actual_properties) - set(want.properties))
+        if extra:
+            return (node, uuid), f"unexpected properties {extra}"
+        for name, value in want.properties.items():
+            if actual_properties.get(name) != value:
+                return (node, uuid), (
+                    f"property {name}: expected {value!r}, got {actual_properties.get(name)!r}"
+                )
+        if not vectors_equal(want.vectors, normalise_vectors(payload)):
+            return (node, uuid), "vector mismatch"
+        return (node, uuid), None
+
+    problems: dict[tuple[str, str], str] = {}
+    while pending:
+        # return_exceptions keeps one read's transport failure from abandoning the whole sweep; the
+        # id stays unresolved and takes the same retry path as a mismatch.
+        results = await asyncio.gather(
+            *(check(node, uuid) for node, uuid in pending), return_exceptions=True
+        )
+        problems = {}
+        for key, result in zip(pending, results):
+            if isinstance(result, BaseException):
+                problems[key] = f"read raised {result!r}"
+            elif result[1] is not None:
+                problems[key] = result[1]
+        pending = list(problems)
+        if not pending or time.monotonic() >= deadline:
+            break
+        await asyncio.sleep(cfg.poll_interval_s)
+
+    for (node, uuid), reason in problems.items():
+        f.add(assertion, f"{class_name} object {uuid} on node {node}: {reason}")
+    if not problems:
+        logger.success(
+            f"{class_name}: {len(snapshot)} objects verified on each of {len(nodes)} replicas"
+        )
+    await _cross_check_counts(cfg, f, root, class_name, len(snapshot), deadline, assertion)
+
+
+async def _cross_check_counts(
+    cfg: Config,
+    f: Failures,
+    root: Rest,
+    class_name: str,
+    expected_count: int,
+    deadline: float,
+    assertion: str,
+) -> None:
+    """Per-node object counts converge asynchronously, so they share the sweep budget.
+
+    The floor keeps a sweep that consumed its whole budget from collapsing this into a single
+    attempt, which would report lag as a failure.
+    """
+    remaining = max(deadline - time.monotonic(), cfg.count_converge_floor_s)
+    total_expected = expected_count * cfg.target_replication_factor
+
+    async def counts() -> tuple[bool, Any]:
+        per_node: dict[str, int] = {}
+        for node in await root.nodes_for_class(class_name, cfg.rest_read_timeout_s * 2):
+            per_node[node["name"]] = sum(
+                shard.get("objectCount", 0)
+                for shard in node.get("shards") or []
+                if shard.get("class") == class_name
+            )
+        return (
+            sum(per_node.values()) == total_expected
+            and all(count <= expected_count for count in per_node.values()),
+            per_node,
+        )
+
+    try:
+        per_node = await poll(
+            counts,
+            deadline_s=remaining,
+            interval_s=cfg.poll_interval_s,
+            describe=f"per-node object counts of {class_name} to reach {total_expected}",
+        )
+        logger.info(f"{class_name} per-node counts: {per_node}")
+    except Exception as exc:
+        f.add(assertion, f"{class_name} per-node object counts never converged: {exc}")
+
+
+async def assert_migrated_users_behave(
+    cfg: Config, f: Failures, state: SourceState, load: NeighbourLoad
+) -> None:
+    """Every migrated user authenticates on the target with its source-issued key and behaves.
+
+    Behavioural by design: no stored permission set, resource string or assignment table is
+    compared, because those bind the test to strip internals rather than to the customer outcome.
+    """
+    assertion = "migrated-users-behave"
+    if _not_quiescent(f, assertion, load):
+        return
+    migrated_class = state.graduating.collections[0].short_name
+    for user in state.graduating.users:
+        stripped = user.short_id
+        try:
+            await _probe_user(cfg, f, user, stripped, migrated_class, assertion)
+        except Exception as exc:
+            f.add(assertion, f"user {stripped}: probe raised {exc!r}")
+
+
+async def _probe_user(
+    cfg: Config,
+    f: Failures,
+    user: seedmod.SeededUser,
+    stripped: str,
+    migrated_class: str,
+    assertion: str,
+) -> None:
+    rest = Rest(
+        cfg.target.http_base_urls,
+        user.api_key,
+        f"target/{stripped}",
+        connect_timeout_s=cfg.rest_connect_timeout_s,
+        read_timeout_s=cfg.rest_read_timeout_s,
+    )
+    client = wvclient.build_client(cfg.target, user.api_key)
+    try:
+        # Authentication. The strip rewrites ids only, never key hashes or identifiers.
+        response = await rest.own_info()
+        if response.status_code != 200:
+            f.add(
+                assertion,
+                f"user {stripped} source-issued key rejected on the target: "
+                f"own-info {response.status_code}",
+            )
+            return
+        await client.connect()
+
+        # Positive probe: every migrated user can read, whatever its capability class. Its failure
+        # is recorded and the capability probes still run: a user that cannot read may still hold
+        # the wrong capability, and that second defect must not be hidden by the first.
+        try:
+            collection = client.collections.use(migrated_class)
+            result = await collection.query.fetch_objects(limit=1)
+            if not result.objects:
+                f.add(assertion, f"user {stripped} read no object from {migrated_class}")
+        except Exception as exc:
+            f.add(assertion, f"user {stripped} could not read {migrated_class}: {exc!r}")
+
+        # Capability probe. The namespace's first user arrives holding the built-in admin, and on a
+        # namespaces-off target all built-ins carry wildcard policies (rbac/model.go:181-193), so
+        # that user is a cluster-wide admin by design: it is probed positively, never negatively.
+        # Derived in config.py, so the artefact summary and preflight name the same class.
+        probe_class = cfg.probe_class_name(stripped)
+        if user.capability == CAPABILITY_NARROW:
+            await _expect_denied(f, client, probe_class, stripped, assertion)
+        else:
+            await _expect_permitted(f, client, probe_class, stripped, assertion)
+    finally:
+        await client.close()
+        await rest.aclose()
+
+
+async def _expect_denied(
+    f: Failures, client: Any, probe_class: str, stripped: str, assertion: str
+) -> None:
+    """exists() is never used here: it catches everything and turns a denial into a bare False."""
+    try:
+        await client.collections.create(name=probe_class)
+    except Exception as exc:
+        if wvclient.is_permission_denied(exc):
+            return
+        f.add(assertion, f"narrow user {stripped} create denied with the wrong error: {exc!r}")
+        return
+    f.add(assertion, f"narrow user {stripped} was allowed to create collection {probe_class}")
+    await _delete_probe(client, probe_class)
+
+
+async def _expect_permitted(
+    f: Failures, client: Any, probe_class: str, stripped: str, assertion: str
+) -> None:
+    try:
+        await client.collections.create(name=probe_class)
+    except Exception as exc:
+        f.add(assertion, f"admin user {stripped} could not create collection: {exc!r}")
+        return
+    await _delete_probe(client, probe_class)
+
+
+async def _delete_probe(client: Any, probe_class: str) -> None:
+    """The probe collection is throwaway; a failed cleanup is logged, not a verdict."""
+    try:
+        await client.collections.delete(probe_class)
+    except Exception as exc:
+        logger.warning(f"could not delete probe collection {probe_class}: {exc!r}")
+
+
+async def assert_target_user_and_role_sets(
+    f: Failures, root: Rest, state: SourceState, load: NeighbourLoad
+) -> None:
+    """Exactly the migrated users and roles exist on the target. This is what makes leakage visible."""
+    assertion = "target-user-and-role-sets"
+    if _not_quiescent(f, assertion, load):
+        return
+    try:
+        expected_users = {user.short_id for user in state.graduating.users}
+        expected_roles = {state.graduating.role_short}
+        # Both claims are cluster-wide and both reads are leader queries
+        # (cluster/raft_query_endpoints.go:374-404), so one rotating read each answers from
+        # authoritative state. db_env_user entries are the target's own static API-key users,
+        # appended to every root-caller response and untouched by the restore.
+        actual_users = set(dynamic_user_ids(await root.list_db_users()))
+        if actual_users != expected_users:
+            f.add(
+                assertion,
+                f"target dynamic users {sorted(actual_users)} != "
+                f"migrated users {sorted(expected_users)}",
+            )
+
+        role_names = set(await root.list_roles())
+        missing_built_ins = {"admin", "viewer"} - role_names
+        if missing_built_ins:
+            f.add(assertion, f"target is missing built-in roles {sorted(missing_built_ins)}")
+        actual_roles = role_names - BUILT_IN_ROLES
+        if actual_roles != expected_roles:
+            f.add(
+                assertion,
+                f"target custom roles {sorted(actual_roles)} != "
+                f"migrated roles {sorted(expected_roles)}",
+            )
+    except Exception as exc:
+        f.add(assertion, f"raised {exc!r}")
+
+
+async def assert_no_leakage_of_neighbour_collections(
+    f: Failures, root: Rest, state: SourceState, load: NeighbourLoad
+) -> None:
+    """No neighbour-derived class name reaches the target, qualified or stripped."""
+    assertion = "no-leakage"
+    if _not_quiescent(f, assertion, load):
+        return
+    try:
+        # The schema dump is a leader query with consistency on by default, so one rotating read is
+        # the cluster's answer.
+        target_classes = set(await root.schema_class_names())
+        for namespace in state.neighbours:
+            for seeded in namespace.collections:
+                for name in (seeded.qualified_name, seeded.short_name):
+                    if name in target_classes:
+                        f.add(assertion, f"neighbour collection {name} appears on the target")
+    except Exception as exc:
+        f.add(assertion, f"raised {exc!r}")
+
+
+async def assert_neighbour_integrity(
+    cfg: Config, f: Failures, root: Rest, state: SourceState, load: NeighbourLoad, label: str
+) -> None:
+    """Neighbour namespaces are untouched. Run after restore and again after the source deletion."""
+    assertion = f"neighbour-integrity/{label}"
+    if _not_quiescent(f, assertion, load):
+        return
+    try:
+        dynamic_users = set(dynamic_user_ids(await root.list_db_users()))
+        role_names = set(await root.list_roles())
+        for namespace in state.neighbours:
+            if namespace.role_qualified not in role_names:
+                f.add(assertion, f"neighbour role {namespace.role_qualified} is gone")
+            for user in namespace.users:
+                if user.user_id not in dynamic_users:
+                    f.add(assertion, f"neighbour user {user.user_id} is gone")
+                async with seedmod.principal_rest(cfg, cfg.source, user) as user_rest:
+                    response = await user_rest.own_info()
+                    if response.status_code != 200:
+                        f.add(
+                            assertion,
+                            f"neighbour user {user.user_id} key no longer authenticates: "
+                            f"own-info {response.status_code}",
+                        )
+            await _compare_neighbour_objects(cfg, f, namespace, assertion)
+    except Exception as exc:
+        f.add(assertion, f"raised {exc!r}")
+
+
+async def _compare_neighbour_objects(
+    cfg: Config, f: Failures, namespace: Any, assertion: str
+) -> None:
+    async with wvclient.connected(cfg.source, namespace.admin_user.api_key) as client:
+        for seeded in namespace.collections:
+            actual: dict[str, ExpectedObject] = await wvclient.read_all(
+                client.collections.use(seeded.short_name)
+            )
+            diffs = seeded.expected.diff(actual)
+            for diff in diffs[:20]:
+                f.add(assertion, f"{namespace.name}: {diff.render()}")
+            if len(diffs) > 20:
+                f.add(assertion, f"{namespace.name}: {len(diffs) - 20} further divergences")
+            if not diffs:
+                logger.success(
+                    f"[{assertion}] {namespace.name}:{seeded.short_name} intact "
+                    f"({len(seeded.expected)} objects)"
+                )
+
+
+async def assert_source_post_state(
+    cfg: Config, f: Failures, root: Rest, state: SourceState, load: NeighbourLoad
+) -> None:
+    """The graduating namespace and everything it owned are gone from the source."""
+    assertion = "source-post-state"
+    if _not_quiescent(f, assertion, load):
+        return
+    namespace = state.graduating.name
+    prefix = f"{namespace}:"
+    try:
+        # All four reads are leader queries (cluster/raft_query_endpoints.go:374-404), so one
+        # rotating read each is a cluster-wide fact.
+        if await root.get_namespace(namespace) is not None:
+            f.add(assertion, f"namespace {namespace} is still present on the source")
+        leftover_users = [
+            u for u in dynamic_user_ids(await root.list_db_users()) if u.startswith(prefix)
+        ]
+        if leftover_users:
+            f.add(assertion, f"users of {namespace} are still present: {leftover_users}")
+        leftover_roles = [r for r in await root.list_roles() if r.startswith(prefix)]
+        if leftover_roles:
+            f.add(assertion, f"roles of {namespace} are still present: {leftover_roles}")
+
+        # The schema arm is polled as insurance only. The namespace 404 above already implies the
+        # classes are gone: cleanup deletes users, aliases, classes and RBAC before removing the
+        # entry, and the apply re-checks emptiness
+        # (usecases/namespace_cleanup/coordinator.go:201-232).
+        async def schema_clean() -> tuple[bool, Any]:
+            names = [n for n in await root.schema_class_names() if n.startswith(prefix)]
+            return not names, names
+
+        try:
+            await poll(
+                schema_clean,
+                deadline_s=cfg.raft_visibility_timeout_s,
+                interval_s=cfg.poll_interval_s,
+                describe=f"classes of {namespace} to disappear from the source schema",
+            )
+        except Exception as exc:
+            f.add(assertion, str(exc))
+    except Exception as exc:
+        f.add(assertion, f"raised {exc!r}")

--- a/apps/namespace-graduation/config.py
+++ b/apps/namespace-graduation/config.py
@@ -1,0 +1,343 @@
+"""Every environment tunable of the namespace-graduation journey, and the names it derives from them.
+
+No other module reads os.environ.
+"""
+
+import json
+import os
+import random
+import re
+import string
+from dataclasses import dataclass, field
+from typing import Any
+
+# entities/schema/validation.go:131-149
+NAMESPACE_RE = re.compile(r"^[a-z0-9][a-z0-9-]{1,34}[a-z0-9]$")
+CLASS_RE = re.compile(r"^[A-Z][A-Za-z0-9]*$")
+BACKUP_ID_RE = re.compile(r"^[a-z0-9_-]+$")
+
+BASE36 = string.digits + string.ascii_lowercase
+
+
+class ConfigError(Exception):
+    """Raised for any invalid or missing configuration. No network call happens before this is clear."""
+
+
+def _raw(name: str) -> str:
+    value = os.environ.get(name)
+    if value is None:
+        return ""
+    return value.strip()
+
+
+def _env_str(name: str, default: str | None = None) -> str:
+    value = _raw(name)
+    if value == "":
+        if default is None:
+            raise ConfigError(f"{name} is required")
+        return default
+    return value
+
+
+def _env_int(name: str, default: int) -> int:
+    value = _raw(name)
+    if value == "":
+        return default
+    try:
+        return int(value)
+    except ValueError as exc:
+        raise ConfigError(f"{name} must be an integer, got {value!r}") from exc
+
+
+def _env_float(name: str, default: float) -> float:
+    value = _raw(name)
+    if value == "":
+        return default
+    try:
+        return float(value)
+    except ValueError as exc:
+        raise ConfigError(f"{name} must be a number, got {value!r}") from exc
+
+
+def _env_bool(name: str, default: bool) -> bool:
+    value = _raw(name).lower()
+    if value == "":
+        return default
+    if value in ("1", "true", "yes", "on"):
+        return True
+    if value in ("0", "false", "no", "off"):
+        return False
+    raise ConfigError(f"{name} must be a boolean, got {value!r}")
+
+
+def _env_json(name: str) -> dict[str, str] | None:
+    value = _raw(name)
+    if value == "":
+        return None
+    try:
+        parsed = json.loads(value)
+    except json.JSONDecodeError as exc:
+        raise ConfigError(f"{name} must be valid JSON, got {value!r}") from exc
+    if not isinstance(parsed, dict) or not all(
+        isinstance(k, str) and isinstance(v, str) for k, v in parsed.items()
+    ):
+        raise ConfigError(f"{name} must be a JSON object of string to string, got {value!r}")
+    return parsed
+
+
+def _env_int_list(name: str, default: str) -> list[int]:
+    value = _env_str(name, default)
+    try:
+        return [int(part.strip()) for part in value.split(",") if part.strip() != ""]
+    except ValueError as exc:
+        raise ConfigError(f"{name} must be a comma-separated list of ports, got {value!r}") from exc
+
+
+def _env_str_list(name: str) -> list[str]:
+    value = _raw(name)
+    if value == "":
+        return []
+    return [part.strip() for part in value.split(",") if part.strip() != ""]
+
+
+def generate_run_id() -> str:
+    return "".join(random.choice(BASE36) for _ in range(6))
+
+
+@dataclass(frozen=True)
+class Cluster:
+    """One Weaviate cluster's addressing and its static root credential."""
+
+    label: str
+    host: str
+    http_ports: list[int]
+    grpc_ports: list[int]
+    http_base_urls: list[str]
+    root_api_key: str
+
+    def grpc_port(self, index: int) -> int:
+        return self.grpc_ports[index % len(self.grpc_ports)]
+
+    def http_port(self, index: int) -> int:
+        return self.http_ports[index % len(self.http_ports)]
+
+
+def _cluster(label: str, prefix: str, host: str, default_http: str, default_grpc: str) -> Cluster:
+    if _raw(f"{prefix}_HTTP_BASE_URLS") != "":
+        # A base URL sets REST addressing only. The weaviate client needs a gRPC host and port, and
+        # neither is derivable from an HTTP base URL, so honouring the override would silently split
+        # REST and gRPC across different endpoints.
+        raise ConfigError(
+            f"{prefix}_HTTP_BASE_URLS is refused: SOURCE_HTTP_BASE_URLS and "
+            "TARGET_HTTP_BASE_URLS override REST addressing only, and no gRPC host or port can be "
+            f"derived from them. Address a non-default rig with WEAVIATE_HOST_ADDR plus "
+            f"{prefix}_HTTP_PORTS and {prefix}_GRPC_PORTS."
+        )
+    http_ports = _env_int_list(f"{prefix}_HTTP_PORTS", default_http)
+    grpc_ports = _env_int_list(f"{prefix}_GRPC_PORTS", default_grpc)
+    if len(http_ports) != len(grpc_ports):
+        raise ConfigError(
+            f"{prefix}_HTTP_PORTS and {prefix}_GRPC_PORTS must have equal length, "
+            f"got {len(http_ports)} and {len(grpc_ports)}"
+        )
+    return Cluster(
+        label=label,
+        host=host,
+        http_ports=http_ports,
+        grpc_ports=grpc_ports,
+        http_base_urls=[f"http://{host}:{port}" for port in http_ports],
+        root_api_key=_env_str(f"{prefix}_ROOT_API_KEY"),
+    )
+
+
+@dataclass(frozen=True)
+class Config:
+    weaviate_version: str
+    run_id: str
+    source: Cluster
+    target: Cluster
+
+    namespace_prefix: str
+    neighbour_namespace_count: int
+    collection_prefix: str
+    collections_per_namespace: int
+    objects_per_collection: int
+    vector_dim: int
+    users_per_namespace: int
+    neighbour_set_target: int
+
+    backup_backend: str
+    backup_id_prefix: str
+    target_replication_factor: int
+    allow_target_store_replacement: bool
+
+    poll_interval_s: float
+    rest_connect_timeout_s: float
+    rest_read_timeout_s: float
+    raft_visibility_timeout_s: float
+    backup_timeout_s: float
+    restore_timeout_s: float
+    scale_op_timeout_s: float
+    sharding_state_timeout_s: float
+    namespace_delete_timeout_s: float
+    per_replica_sweep_timeout_s: float
+    per_replica_sweep_concurrency: int
+    count_converge_floor_s: float
+    load_pause_timeout_s: float
+    neighbour_load_ops_per_second: float
+
+    restore_node_mapping: dict[str, str] | None
+    restore_include: list[str] = field(default_factory=list)
+
+    # --- derived names -------------------------------------------------------
+
+    @property
+    def namespace_count(self) -> int:
+        """Index 1 graduates; 2..N are neighbours."""
+        return self.neighbour_namespace_count + 1
+
+    def namespace_name(self, index: int) -> str:
+        return f"{self.namespace_prefix}-{self.run_id}-ns{index}"
+
+    @property
+    def graduating_namespace(self) -> str:
+        return self.namespace_name(1)
+
+    def neighbour_namespaces(self) -> list[str]:
+        return [self.namespace_name(i) for i in range(2, self.namespace_count + 1)]
+
+    def collection_short_name(self, serial: int) -> str:
+        """serial counts across the whole run, so no two namespaces produce the same stripped class name."""
+        return f"{self.collection_prefix}{self.run_id.capitalize()}Coll{serial}"
+
+    def collection_serials(self, namespace_index: int) -> list[int]:
+        first = (namespace_index - 1) * self.collections_per_namespace + 1
+        return list(range(first, first + self.collections_per_namespace))
+
+    def user_short_name(self, serial: int) -> str:
+        """serial counts across the whole run, for the same reason as collection_short_name."""
+        return f"u{self.run_id}{serial}"
+
+    def user_serials(self, namespace_index: int) -> list[int]:
+        first = (namespace_index - 1) * self.users_per_namespace + 1
+        return list(range(first, first + self.users_per_namespace))
+
+    def role_short_name(self, namespace_index: int) -> str:
+        return f"w{self.run_id}{namespace_index}"
+
+    @property
+    def backup_id(self) -> str:
+        return f"{self.backup_id_prefix}_{self.run_id}"
+
+    def all_collection_short_names(self) -> list[str]:
+        return [
+            self.collection_short_name(serial)
+            for index in range(1, self.namespace_count + 1)
+            for serial in self.collection_serials(index)
+        ]
+
+    def graduating_collection_short_names(self) -> list[str]:
+        return [self.collection_short_name(serial) for serial in self.collection_serials(1)]
+
+    def graduating_user_short_names(self) -> list[str]:
+        """The user ids this run's restore will produce on the target, after the namespace strip."""
+        return [self.user_short_name(serial) for serial in self.user_serials(1)]
+
+    def probe_class_name(self, user_short_name: str) -> str:
+        """The throwaway class one migrated user's capability probe creates on the target."""
+        return f"{self.graduating_collection_short_names()[0]}Probe{user_short_name.capitalize()}"
+
+    def probe_class_names(self) -> list[str]:
+        """Derivable before anything exists, so the artefact summary and preflight both name them.
+
+        Every migrated user's probe is listed, not only the admin's: a narrow user's probe leaves a
+        class behind exactly when its denial fails.
+        """
+        return [self.probe_class_name(name) for name in self.graduating_user_short_names()]
+
+    # --- validation ----------------------------------------------------------
+
+    def validate(self) -> None:
+        if self.neighbour_namespace_count < 2:
+            raise ConfigError("NEIGHBOUR_NAMESPACE_COUNT must be at least 2")
+        if self.collections_per_namespace < 2:
+            raise ConfigError("COLLECTIONS_PER_NAMESPACE must be at least 2")
+        if self.users_per_namespace < 2:
+            raise ConfigError("USERS_PER_NAMESPACE must be at least 2")
+        if self.objects_per_collection < 1:
+            raise ConfigError("OBJECTS_PER_COLLECTION must be at least 1")
+        if self.per_replica_sweep_concurrency < 1:
+            raise ConfigError("PER_REPLICA_SWEEP_CONCURRENCY must be at least 1")
+        if self.neighbour_load_ops_per_second <= 0:
+            raise ConfigError("NEIGHBOUR_LOAD_OPS_PER_SECOND must be positive")
+        if not BACKUP_ID_RE.match(self.backup_id):
+            raise ConfigError(
+                f"derived backup id {self.backup_id!r} must match {BACKUP_ID_RE.pattern} "
+                "— check BACKUP_ID_PREFIX and RUN_ID"
+            )
+        for index in range(1, self.namespace_count + 1):
+            name = self.namespace_name(index)
+            if not NAMESPACE_RE.match(name):
+                raise ConfigError(
+                    f"derived namespace {name!r} must match {NAMESPACE_RE.pattern} "
+                    "— check NAMESPACE_PREFIX and RUN_ID"
+                )
+        for name in self.all_collection_short_names() + self.probe_class_names():
+            if not CLASS_RE.match(name):
+                raise ConfigError(
+                    f"derived collection {name!r} must match {CLASS_RE.pattern} "
+                    "— check COLLECTION_PREFIX and RUN_ID"
+                )
+
+    @staticmethod
+    def from_env() -> "Config":
+        host = _env_str("WEAVIATE_HOST_ADDR", "host.docker.internal")
+        cfg = Config(
+            weaviate_version=_env_str("WEAVIATE_VERSION"),
+            run_id=_env_str("RUN_ID", generate_run_id()).lower(),
+            # The source cluster is a single node (docker-compose-namespaces-source.yml).
+            source=_cluster("source", "SOURCE", host, "18080", "18090"),
+            target=_cluster("target", "TARGET", host, "18180,18181,18182", "18190,18191,18192"),
+            namespace_prefix=_env_str("NAMESPACE_PREFIX", "grad"),
+            neighbour_namespace_count=_env_int("NEIGHBOUR_NAMESPACE_COUNT", 2),
+            collection_prefix=_env_str("COLLECTION_PREFIX", "Grad"),
+            collections_per_namespace=_env_int("COLLECTIONS_PER_NAMESPACE", 2),
+            objects_per_collection=_env_int("OBJECTS_PER_COLLECTION", 200),
+            vector_dim=_env_int("VECTOR_DIM", 32),
+            users_per_namespace=_env_int("USERS_PER_NAMESPACE", 2),
+            neighbour_set_target=_env_int("NEIGHBOUR_SET_TARGET", 400),
+            backup_backend=_env_str("BACKUP_BACKEND", "s3"),
+            backup_id_prefix=_env_str("BACKUP_ID_PREFIX", "nsgrad"),
+            target_replication_factor=_env_int("TARGET_REPLICATION_FACTOR", 3),
+            allow_target_store_replacement=_env_bool("ALLOW_TARGET_STORE_REPLACEMENT", False),
+            poll_interval_s=_env_float("POLL_INTERVAL_S", 3),
+            rest_connect_timeout_s=_env_float("REST_CONNECT_TIMEOUT_S", 5),
+            rest_read_timeout_s=_env_float("REST_READ_TIMEOUT_S", 30),
+            raft_visibility_timeout_s=_env_float("RAFT_VISIBILITY_TIMEOUT_S", 30),
+            backup_timeout_s=_env_float("BACKUP_TIMEOUT_S", 600),
+            restore_timeout_s=_env_float("RESTORE_TIMEOUT_S", 900),
+            scale_op_timeout_s=_env_float("SCALE_OP_TIMEOUT_S", 600),
+            sharding_state_timeout_s=_env_float("SHARDING_STATE_TIMEOUT_S", 120),
+            namespace_delete_timeout_s=_env_float("NAMESPACE_DELETE_TIMEOUT_S", 300),
+            per_replica_sweep_timeout_s=_env_float("PER_REPLICA_SWEEP_TIMEOUT_S", 300),
+            per_replica_sweep_concurrency=_env_int("PER_REPLICA_SWEEP_CONCURRENCY", 8),
+            count_converge_floor_s=_env_float("COUNT_CONVERGE_FLOOR_S", 10),
+            load_pause_timeout_s=_env_float("LOAD_PAUSE_TIMEOUT_S", 60),
+            neighbour_load_ops_per_second=_env_float("NEIGHBOUR_LOAD_OPS_PER_SECOND", 10),
+            restore_node_mapping=_env_json("RESTORE_NODE_MAPPING"),
+            restore_include=_env_str_list("RESTORE_INCLUDE"),
+        )
+        cfg.validate()
+        return cfg
+
+    def summary(self) -> dict[str, Any]:
+        return {
+            "run_id": self.run_id,
+            "weaviate_version": self.weaviate_version,
+            "source_urls": self.source.http_base_urls,
+            "target_urls": self.target.http_base_urls,
+            "graduating_namespace": self.graduating_namespace,
+            "neighbour_namespaces": self.neighbour_namespaces(),
+            "collections": self.all_collection_short_names(),
+            "backup_id": self.backup_id,
+        }

--- a/apps/namespace-graduation/graduate.py
+++ b/apps/namespace-graduation/graduate.py
@@ -1,0 +1,212 @@
+"""The graduation itself: backup, restore, rf=1->3 scale-out, source-namespace deletion."""
+
+from typing import Any
+
+from loguru import logger
+
+from config import Config
+from restapi import (
+    REPLICATION_CANCELLED,
+    REPLICATION_IN_PROGRESS,
+    REPLICATION_READY,
+    Rest,
+    backup_reached_success,
+    poll,
+)
+
+
+class GraduationError(Exception):
+    """A graduation step failed. Every step here fails fast."""
+
+
+async def create_backup(cfg: Config, root: Rest, expected_classes: list[str]) -> str:
+    """Wildcard-select the graduating namespace's classes, users and roles, and wait for SUCCESS.
+
+    Driven by the global operator: backup create is denied to a namespace-bound principal.
+    """
+    namespace = cfg.graduating_namespace
+    backup_id = cfg.backup_id
+    # Pinned for the whole transaction: OnStatus answers from the coordinating node's in-memory
+    # lastOp, while every other node answers from the object store's global descriptor, which is
+    # only rewritten at phase transitions (usecases/backup/coordinator.go:460-479).
+    transaction = root.pinned()
+    body = {
+        "id": backup_id,
+        "include": [f"{namespace}:*"],
+        "includeUsers": [f"{namespace}:*"],
+        "includeRoles": [f"{namespace}:*"],
+    }
+    logger.info(f"creating backup {backup_id} on {transaction.pinned_url} with {body}")
+    response = await transaction.backup_create(cfg.backup_backend, body)
+
+    # The POST response is the only place the resolved wildcard selection appears; the status
+    # response carries no classes field. A wildcard matching nothing is a server-side error
+    # (usecases/backup/scheduler.go:769-771), so an empty migration cannot pass unnoticed.
+    selected = sorted(response.get("classes") or [])
+    if selected != sorted(expected_classes):
+        raise GraduationError(
+            f"backup {backup_id} selected {selected}, expected {sorted(expected_classes)}"
+        )
+
+    async def status() -> tuple[bool, Any]:
+        # A status 404 raises: both operations write their global descriptor synchronously before
+        # the POST returns (coordinator.go:222 and :301), so there is no not-yet-written window.
+        payload = await transaction.backup_status(cfg.backup_backend, backup_id)
+        return backup_reached_success(payload, f"backup {backup_id}"), payload.get("status")
+
+    await poll(
+        status,
+        deadline_s=cfg.backup_timeout_s,
+        interval_s=cfg.poll_interval_s,
+        describe=f"backup {backup_id} to reach SUCCESS",
+    )
+    logger.success(f"backup {backup_id} succeeded with classes {selected}")
+    return backup_id
+
+
+async def restore_backup(cfg: Config, root: Rest, backup_id: str) -> None:
+    """Restore onto the target with users and roles included, and wait for SUCCESS.
+
+    Both options default to noRestore, which would migrate no users and no roles while still
+    reporting SUCCESS. `include` is omitted deliberately: the backup already holds exactly the
+    graduating namespace's classes, and restore-side include filtering happens pre-strip, so it
+    would have to name the original qualified classes (usecases/backup/restorer.go:304-311).
+    """
+    transaction = root.pinned()
+    body: dict[str, Any] = {"config": {"usersOptions": "all", "rolesOptions": "all"}}
+    if cfg.restore_node_mapping:
+        body["node_mapping"] = cfg.restore_node_mapping
+    if cfg.restore_include:
+        body["include"] = cfg.restore_include
+    logger.info(f"restoring {backup_id} on {transaction.pinned_url} with {body}")
+    await transaction.backup_restore(cfg.backup_backend, backup_id, body)
+
+    async def status() -> tuple[bool, Any]:
+        payload = await transaction.restore_status(cfg.backup_backend, backup_id)
+        return backup_reached_success(payload, f"restore {backup_id}"), payload.get("status")
+
+    await poll(
+        status,
+        deadline_s=cfg.restore_timeout_s,
+        interval_s=cfg.poll_interval_s,
+        describe=f"restore of {backup_id} to reach SUCCESS",
+    )
+    logger.success(f"restore of {backup_id} succeeded")
+
+
+async def scale_out(cfg: Config, root: Rest, class_names: list[str]) -> None:
+    """Scale each migrated collection to TARGET_REPLICATION_FACTOR, one collection at a time."""
+    for class_name in class_names:
+        await _scale_one(cfg, root, class_name)
+
+
+async def _scale_one(cfg: Config, root: Rest, class_name: str) -> None:
+    # Pre-apply gate. The server rejects an apply while any op for the collection is neither READY
+    # nor CANCELLED (cluster/raft_replication_apply_endpoints.go:31-39) and surfaces that as an
+    # opaque 500. Naming the blocking ops is what makes a re-run after an abort diagnosable.
+    blocking = [
+        (op.get("id"), (op.get("status") or {}).get("state"))
+        for op in await root.replication_ops_for(class_name)
+        if (op.get("status") or {}).get("state") not in (REPLICATION_READY, REPLICATION_CANCELLED)
+    ]
+    if blocking:
+        raise GraduationError(
+            f"cannot scale {class_name}: replication operations still in flight {blocking}"
+        )
+
+    response = await root.scale_plan(class_name, cfg.target_replication_factor)
+    if response.status_code != 200:
+        raise GraduationError(
+            f"scale plan for {class_name} -> rf={cfg.target_replication_factor} returned "
+            f"{response.status_code}: {response.text}"
+        )
+    plan = response.json()
+    logger.info(f"applying scale plan for {class_name}: {plan}")
+
+    # The plan is posted verbatim: the server rebuilds the actions from the body and echoes only
+    # planId, so a reconstructed body would not round-trip.
+    applied = await root.scale_apply(plan)
+    operation_ids = [str(op_id) for op_id in applied.get("operationIds") or []]
+    if not operation_ids:
+        raise GraduationError(f"scale apply for {class_name} registered no operations: {applied}")
+
+    for operation_id in operation_ids:
+
+        async def ready(operation_id: str = operation_id) -> tuple[bool, Any]:
+            details = await root.replication_details(operation_id)
+            status = details.get("status") or {}
+            state = status.get("state")
+            errors = status.get("errors") or []
+            if errors:
+                # Diagnostic, never a verdict: ChangeState clears errors at every transition and
+                # AddError records retried transients, so a healthy operation that retried once
+                # carries them (cluster/replication/shard_replication_op_state.go:26,124-143).
+                logger.warning(
+                    f"replication operation {operation_id} of {class_name} in state {state} "
+                    f"reports errors {errors}"
+                )
+            if state == REPLICATION_CANCELLED:
+                raise GraduationError(
+                    f"replication operation {operation_id} of {class_name} was cancelled: "
+                    f"state={state} errors={errors}"
+                )
+            if state == REPLICATION_READY:
+                return True, state
+            if state not in REPLICATION_IN_PROGRESS:
+                # Symmetric with the backup poll: an unrecognised state fails now rather than
+                # spinning to the timeout.
+                raise GraduationError(
+                    f"replication operation {operation_id} of {class_name} reported unknown "
+                    f"state {state!r}: {details}"
+                )
+            return False, state
+
+        await poll(
+            ready,
+            deadline_s=cfg.scale_op_timeout_s,
+            interval_s=cfg.poll_interval_s,
+            describe=f"replication operation {operation_id} of {class_name} to reach READY",
+        )
+
+    async def replicated() -> tuple[bool, Any]:
+        shards = (await root.sharding_state(class_name)).get("shards") or []
+        counts = {shard.get("shard"): len(shard.get("replicas") or []) for shard in shards}
+        done = bool(counts) and all(
+            count == cfg.target_replication_factor for count in counts.values()
+        )
+        return done, counts
+
+    counts = await poll(
+        replicated,
+        deadline_s=cfg.sharding_state_timeout_s,
+        interval_s=cfg.poll_interval_s,
+        describe=f"every shard of {class_name} to report {cfg.target_replication_factor} replicas",
+    )
+    # The apply issues per-shard replica commands and never touches the class definition
+    # (cluster/raft_replication_apply_endpoints.go:78-121), so replicationConfig.factor still reads
+    # 1 afterwards. rf is proven from sharding state alone.
+    logger.success(f"{class_name} scaled out: {counts}")
+
+
+async def delete_source_namespace(cfg: Config, root: Rest) -> None:
+    """Delete the graduating namespace and wait for absence. Gone is a 404, not a state."""
+    namespace = cfg.graduating_namespace
+    await root.delete_namespace(namespace)
+
+    async def absent() -> tuple[bool, Any]:
+        current = await root.get_namespace(namespace)
+        if current is None:
+            return True, "absent"
+        return False, current.get("state")
+
+    await poll(
+        absent,
+        deadline_s=cfg.namespace_delete_timeout_s,
+        interval_s=cfg.poll_interval_s,
+        describe=f"namespace {namespace} to disappear",
+    )
+    # Cleanup runs on the RAFT leader's tick and the entry is not removed while anything it owns
+    # remains, so a 404 implies the namespace's users, aliases, classes and RBAC rows are gone. The
+    # read is a leader query (cluster/raft_query_endpoints.go:374-404), so that 404 is a
+    # cluster-wide fact, whichever node this rotating poll addressed.
+    logger.success(f"namespace {namespace} is gone from the source")

--- a/apps/namespace-graduation/load.py
+++ b/apps/namespace-graduation/load.py
@@ -1,0 +1,280 @@
+"""Continuous neighbour-namespace write load, model-tracked, pausable and size-governed.
+
+One asyncio task per (neighbour namespace, collection). Each task is the sole writer of its
+ExpectedSet, so the model needs no lock; a second writer would be a design error.
+"""
+
+import asyncio
+import random
+import uuid as uuidlib
+from typing import Any
+
+import httpx
+from loguru import logger
+from weaviate.exceptions import UnexpectedStatusCodeError, WeaviateBaseError
+
+import wvclient
+from config import Config
+from model import ExpectedObject, ExpectedSet
+from restapi import poll
+from seed import SeededCollection, SeededNamespace, SourceState, object_properties
+
+
+class LoadError(Exception):
+    """The load could not keep the model authoritative. Neighbour integrity would be vacuous."""
+
+
+class _Worker:
+    def __init__(self, namespace: SeededNamespace, seeded: SeededCollection, collection: Any):
+        self.key = f"{namespace.name}:{seeded.short_name}"
+        self.seeded = seeded
+        self.collection = collection
+        self.parked = True
+
+
+class NeighbourLoad:
+    def __init__(self, cfg: Config, state: SourceState):
+        self._cfg = cfg
+        self._state = state
+        self._running = asyncio.Event()
+        self._stopping = False
+        self._stopped = False
+        self._workers: list[_Worker] = []
+        self._tasks: list[asyncio.Task] = []
+        self._clients: list[Any] = []
+        self._failure: BaseException | None = None
+
+    # --- lifecycle ----------------------------------------------------------
+
+    async def start(self) -> None:
+        for namespace in self._state.neighbours:
+            client = wvclient.build_client(self._cfg.source, namespace.admin_user.api_key)
+            await client.connect()
+            self._clients.append(client)
+            for seeded in namespace.collections:
+                self._workers.append(
+                    _Worker(namespace, seeded, client.collections.use(seeded.short_name))
+                )
+        self._running.set()
+        for worker in self._workers:
+            self._tasks.append(asyncio.create_task(self._run(worker), name=f"load:{worker.key}"))
+        logger.info(f"neighbour load started on {len(self._workers)} collections")
+
+    async def pause(self) -> None:
+        """Quiesce barrier: return only once every task is parked between operations."""
+        self._running.clear()
+        await poll(
+            self._all_parked,
+            deadline_s=self._cfg.load_pause_timeout_s,
+            interval_s=0.2,
+            describe="neighbour load to quiesce",
+        )
+        self.raise_if_failed()
+
+    async def resume(self) -> None:
+        if not self._stopping:
+            self._running.set()
+
+    def paused(self) -> "_PausedLoad":
+        return _PausedLoad(self)
+
+    def is_quiescent(self) -> bool:
+        """True while paused and after stopping. Every model comparison checks this first."""
+        if self._stopped:
+            return True
+        if self._running.is_set():
+            return False
+        return all(w.parked or t.done() for w, t in zip(self._workers, self._tasks))
+
+    async def stop_and_drain(self) -> None:
+        if self._stopped:
+            return
+        self._stopping = True
+        # Stop wins over pause everywhere: releasing the waiters before awaiting the tasks means a
+        # task parked in a pause cannot outlive a stop, and a raise inside a paused block cannot
+        # deadlock this call.
+        self._running.set()
+        if self._tasks:
+            await asyncio.gather(*self._tasks, return_exceptions=True)
+        self._stopped = True
+        for worker in self._workers:
+            try:
+                actual = await wvclient.read_all(worker.collection)
+            except Exception as exc:  # the drain read is diagnostic, never the run's verdict
+                logger.warning(f"[{worker.key}] drain read failed: {exc!r}")
+                continue
+            diffs = worker.seeded.expected.diff(actual)
+            if diffs:
+                logger.warning(
+                    f"[{worker.key}] {len(diffs)} residual divergences after drain: "
+                    + "; ".join(diff.render() for diff in diffs[:10])
+                )
+        for client in self._clients:
+            await client.close()
+        self._clients = []
+        logger.info("neighbour load stopped")
+        self.raise_if_failed()
+
+    def raise_if_failed(self) -> None:
+        if self._failure is not None:
+            raise LoadError(f"neighbour load task failed: {self._failure!r}") from self._failure
+
+    async def _all_parked(self) -> tuple[bool, Any]:
+        busy = [w.key for w, t in zip(self._workers, self._tasks) if not (w.parked or t.done())]
+        return not busy, busy
+
+    # --- the task -----------------------------------------------------------
+
+    async def _run(self, worker: _Worker) -> None:
+        rng = random.Random(f"{self._cfg.run_id}/load/{worker.key}")
+        interval = 1.0 / self._cfg.neighbour_load_ops_per_second
+        try:
+            while True:
+                worker.parked = True
+                await self._running.wait()
+                worker.parked = False
+                if self._stopping:
+                    return
+                await self._one_operation(worker, rng)
+                await asyncio.sleep(interval)
+        except asyncio.CancelledError:
+            raise
+        except BaseException as exc:
+            # A dead load task must never be tolerated: neighbour integrity would pass vacuously.
+            self._failure = exc
+            logger.error(f"[{worker.key}] load task failed: {exc!r}")
+            self._stopping = True
+            self._running.set()
+            raise
+
+    def _choose_operation(self, expected: ExpectedSet, rng: random.Random) -> str:
+        """Set-size governor: the set oscillates around NEIGHBOUR_SET_TARGET instead of growing."""
+        size = len(expected)
+        if size == 0:
+            return "insert"
+        if size < self._cfg.neighbour_set_target:
+            return rng.choices(["insert", "update", "delete"], weights=(6, 3, 1))[0]
+        return rng.choices(["insert", "update", "delete"], weights=(1, 3, 6))[0]
+
+    async def _one_operation(self, worker: _Worker, rng: random.Random) -> None:
+        expected = worker.seeded.expected
+        operation = self._choose_operation(expected, rng)
+        if operation == "insert":
+            uuid = str(uuidlib.UUID(int=rng.getrandbits(128), version=4))
+            await self._apply(worker, "insert", uuid, self._object(worker, uuid, rng))
+            return
+        uuid = rng.choice(expected.uuids())
+        if operation == "delete":
+            await self._apply(worker, "delete", uuid, None)
+            return
+        await self._apply(worker, "update", uuid, self._object(worker, uuid, rng))
+
+    def _object(self, worker: _Worker, uuid: str, rng: random.Random) -> ExpectedObject:
+        return ExpectedObject(
+            uuid=uuid,
+            properties=object_properties(worker.seeded.short_name, rng.randrange(10**6)),
+            vectors={wvclient.VECTOR_NAME: wvclient.random_vector(rng, self._cfg.vector_dim)},
+        )
+
+    async def _apply(
+        self, worker: _Worker, operation: str, uuid: str, obj: ExpectedObject | None
+    ) -> None:
+        data = worker.collection.data
+        try:
+            if operation == "insert":
+                assert obj is not None
+                await data.insert(
+                    properties=obj.properties,
+                    uuid=obj.uuid,
+                    vector={wvclient.VECTOR_NAME: obj.vectors[wvclient.VECTOR_NAME]},
+                )
+            elif operation == "update":
+                assert obj is not None
+                await data.replace(
+                    uuid=obj.uuid,
+                    properties=obj.properties,
+                    vector={wvclient.VECTOR_NAME: obj.vectors[wvclient.VECTOR_NAME]},
+                )
+            else:
+                await data.delete_by_id(uuid)
+        except BaseException as exc:
+            await self._handle_failure(worker, operation, uuid, exc)
+            return
+        # Recorded only after the server acknowledged.
+        if operation == "delete":
+            worker.seeded.expected.record_delete(uuid)
+        elif operation == "insert":
+            assert obj is not None
+            worker.seeded.expected.record_insert(obj)
+        else:
+            assert obj is not None
+            worker.seeded.expected.record_update(obj)
+
+    async def _handle_failure(
+        self, worker: _Worker, operation: str, uuid: str, exc: BaseException
+    ) -> None:
+        limit = wvclient.usage_limit_rejection(exc)
+        if limit is not None:
+            # The operator guarantees MAXIMUM_ALLOWED_OBJECTS_COUNT is unset or high enough. It is
+            # not readable over REST, so this is the only backstop; swallowing it would throttle the
+            # load to zero effective inserts and make neighbour integrity near-vacuous.
+            raise LoadError(
+                "the rig's MAXIMUM_ALLOWED_OBJECTS_COUNT has been reached, contradicting the "
+                f"operator's guarantee ({worker.key}, {operation}): {limit}"
+            )
+        if isinstance(exc, UnexpectedStatusCodeError) and 400 <= exc.status_code < 500:
+            # The server answered before writing anything; the model stays as it is.
+            logger.warning(f"[{worker.key}] {operation} {uuid} rejected: {exc!r}")
+            return
+        if isinstance(exc, (httpx.HTTPError, WeaviateBaseError, OSError, asyncio.TimeoutError)):
+            logger.warning(f"[{worker.key}] {operation} {uuid} ambiguous ({exc!r}), reconciling")
+            await self._reconcile(worker, uuid)
+            return
+        raise exc
+
+    async def _reconcile(self, worker: _Worker, uuid: str) -> None:
+        """Ask the server what it holds. This test kills no nodes, so a failure here is a defect."""
+
+        async def attempt() -> tuple[bool, Any]:
+            try:
+                obj = await worker.collection.query.fetch_object_by_id(uuid, include_vector=True)
+            except Exception as exc:
+                return False, repr(exc)
+            if obj is None:
+                worker.seeded.expected.record_delete(uuid)
+                return True, "absent"
+            worker.seeded.expected.record_update(
+                ExpectedObject(
+                    uuid=str(obj.uuid),
+                    properties=dict(obj.properties),
+                    vectors={name: list(values) for name, values in (obj.vector or {}).items()},
+                )
+            )
+            return True, "present"
+
+        try:
+            await poll(
+                attempt,
+                deadline_s=self._cfg.raft_visibility_timeout_s,
+                interval_s=self._cfg.poll_interval_s,
+                describe=f"reconciliation of {worker.key} object {uuid}",
+            )
+        except Exception as exc:
+            raise LoadError(
+                f"[{worker.key}] could not reconcile object {uuid}; the model is no longer "
+                f"authoritative: {exc!r}"
+            ) from exc
+
+
+class _PausedLoad:
+    """Pause on enter, resume on exit — including when the body raises."""
+
+    def __init__(self, load: NeighbourLoad):
+        self._load = load
+
+    async def __aenter__(self) -> NeighbourLoad:
+        await self._load.pause()
+        return self._load
+
+    async def __aexit__(self, *exc: object) -> None:
+        await self._load.resume()

--- a/apps/namespace-graduation/model.py
+++ b/apps/namespace-graduation/model.py
@@ -1,0 +1,126 @@
+"""The authoritative in-memory object model, and the diff every equality assertion reports through."""
+
+import math
+from dataclasses import dataclass, field
+from typing import Any
+
+VECTOR_REL_TOL = 1e-6
+VECTOR_ABS_TOL = 1e-6
+
+
+@dataclass(frozen=True)
+class ExpectedObject:
+    uuid: str
+    properties: dict[str, Any]
+    vectors: dict[str, list[float]]
+
+
+@dataclass(frozen=True)
+class Diff:
+    kind: str  # missing | unexpected | property_mismatch | vector_mismatch
+    collection: str
+    uuid: str
+    field: str = ""
+    expected: Any = None
+    actual: Any = None
+
+    def render(self) -> str:
+        base = f"{self.kind} collection={self.collection} id={self.uuid}"
+        if self.field:
+            return f"{base} field={self.field} expected={self.expected!r} actual={self.actual!r}"
+        return base
+
+
+def vectors_equal(a: dict[str, list[float]], b: dict[str, list[float]]) -> bool:
+    """Vectors round-trip through float32 storage, so equality is elementwise isclose."""
+    if set(a) != set(b):
+        return False
+    for name, left in a.items():
+        right = b[name]
+        if len(left) != len(right):
+            return False
+        for x, y in zip(left, right):
+            if not math.isclose(x, y, rel_tol=VECTOR_REL_TOL, abs_tol=VECTOR_ABS_TOL):
+                return False
+    return True
+
+
+def normalise_vectors(obj_json: dict[str, Any]) -> dict[str, list[float]]:
+    """Map a raw REST object onto the model's vector shape.
+
+    `vectors` passes through and wins when both forms are present; a legacy top-level `vector`
+    becomes the named default. The client side needs no normalisation: obj.vector is already a dict.
+    """
+    named = obj_json.get("vectors")
+    if isinstance(named, dict) and named:
+        return {name: list(values) for name, values in named.items()}
+    legacy = obj_json.get("vector")
+    if legacy:
+        return {"default": list(legacy)}
+    return {}
+
+
+@dataclass
+class ExpectedSet:
+    """One collection's expected contents. Exactly one writer: its load task, or the seeder.
+
+    Mutations are recorded only after the server acknowledges them.
+    """
+
+    collection: str
+    _objects: dict[str, ExpectedObject] = field(default_factory=dict)
+
+    def record_insert(self, obj: ExpectedObject) -> None:
+        self._objects[obj.uuid] = obj
+
+    def record_update(self, obj: ExpectedObject) -> None:
+        self._objects[obj.uuid] = obj
+
+    def record_delete(self, uuid: str) -> None:
+        self._objects.pop(uuid, None)
+
+    def snapshot(self) -> dict[str, ExpectedObject]:
+        return dict(self._objects)
+
+    def uuids(self) -> list[str]:
+        return list(self._objects)
+
+    def __len__(self) -> int:
+        return len(self._objects)
+
+    def diff(self, actual: dict[str, ExpectedObject]) -> list[Diff]:
+        diffs: list[Diff] = []
+        expected = self.snapshot()
+        for uuid, want in expected.items():
+            have = actual.get(uuid)
+            if have is None:
+                diffs.append(Diff("missing", self.collection, uuid))
+                continue
+            # Two-sided: a property the model never wrote is a divergence, not a detail.
+            for name in sorted(set(want.properties) | set(have.properties)):
+                if have.properties.get(name) != want.properties.get(name):
+                    diffs.append(
+                        Diff(
+                            "property_mismatch",
+                            self.collection,
+                            uuid,
+                            name,
+                            want.properties.get(name),
+                            have.properties.get(name),
+                        )
+                    )
+            if not vectors_equal(want.vectors, have.vectors):
+                diffs.append(
+                    Diff(
+                        "vector_mismatch",
+                        self.collection,
+                        uuid,
+                        "vectors",
+                        {k: len(v) for k, v in want.vectors.items()},
+                        {k: len(v) for k, v in have.vectors.items()},
+                    )
+                )
+        for uuid in actual:
+            if uuid not in expected:
+                diffs.append(Diff("unexpected", self.collection, uuid))
+        return diffs

--- a/apps/namespace-graduation/requirements.txt
+++ b/apps/namespace-graduation/requirements.txt
@@ -1,0 +1,3 @@
+weaviate-client==4.22.0
+loguru==0.7.2
+httpx==0.28.1

--- a/apps/namespace-graduation/restapi.py
+++ b/apps/namespace-graduation/restapi.py
@@ -1,0 +1,459 @@
+"""Authenticated async REST over httpx, plus the polling primitive every wait in this app uses.
+
+The weaviate client covers no namespace, backup, replication, user or role endpoint, so this layer
+carries all of them. Control flow keys on status codes only: namespace lifecycle errors all render as
+the single opaque string "instance unavailable" (usecases/namespaces/public_message.go:21-34), so
+server message text is never parsed.
+"""
+
+import asyncio
+import time
+from typing import Any, Awaitable, Callable, Iterable, Sequence
+
+import httpx
+from loguru import logger
+
+# Bounded schedule for the idempotent-only retry policy below. Deliberately not an env tunable:
+# it parametrises a policy that lives in this module and nowhere else.
+_RETRY_ATTEMPTS = 3
+_RETRY_BACKOFF_S = 1.0
+_RETRY_METHODS = frozenset({"GET", "DELETE"})
+_RETRY_STATUSES = frozenset({502, 503})
+
+# entities/backup/status.go:16-25. FINALIZING is on the restore happy path; note the wire spelling
+# asymmetry: CANCELLING has two Ls, CANCELED has one.
+BACKUP_IN_PROGRESS = frozenset({"STARTED", "TRANSFERRING", "TRANSFERRED", "FINALIZING"})
+BACKUP_SUCCESS = "SUCCESS"
+BACKUP_TERMINAL_FAILURE = frozenset({"FAILED", "CANCELLING", "CANCELED"})
+
+# ReplicationReplicateDetailsReplicaStatus.state. CANCELLED is the only terminal failure; the
+# status.errors rationale lives with the operation poll that acts on it, in graduate.py.
+REPLICATION_READY = "READY"
+REPLICATION_CANCELLED = "CANCELLED"
+REPLICATION_IN_PROGRESS = frozenset(
+    {"REGISTERED", "HYDRATING", "FINALIZING", "INTEGRATING", "DEHYDRATING"}
+)
+
+
+class _AnyStatus:
+    """Sentinel for `expect`: return whatever the server answered, so the caller classifies it."""
+
+
+ANY_STATUS = _AnyStatus()
+
+
+class RestError(Exception):
+    """A response outside the caller's expected status set. Carries the server's body verbatim."""
+
+    def __init__(self, label: str, method: str, path: str, status: int, body: str):
+        self.label = label
+        self.method = method
+        self.path = path
+        self.status = status
+        self.body = body
+        super().__init__(f"[{label}] {method} {path} -> {status}: {body}")
+
+
+class PollTimeout(Exception):
+    """A bounded wait expired. Names what was awaited and the last observation."""
+
+
+class BackupStateError(Exception):
+    """A backup or restore reached a terminal failure state, or reported an unknown one."""
+
+
+async def poll(
+    fn: Callable[[], Awaitable[tuple[bool, Any]]],
+    *,
+    deadline_s: float,
+    interval_s: float,
+    describe: str,
+) -> Any:
+    """Await fn() until it reports done. fn returns (done, observation); raising from fn fails fast."""
+    deadline = time.monotonic() + deadline_s
+    observation: Any = None
+    while True:
+        done, observation = await fn()
+        if done:
+            return observation
+        if time.monotonic() >= deadline:
+            raise PollTimeout(
+                f"timed out after {deadline_s:g}s waiting for {describe}; "
+                f"last observation: {observation!r}"
+            )
+        await asyncio.sleep(interval_s)
+
+
+def backup_reached_success(payload: dict[str, Any], describe: str) -> bool:
+    """Classify one status payload against the eight-value enum. No status is merely tolerated."""
+    status = payload.get("status")
+    if status == BACKUP_SUCCESS:
+        return True
+    if status in BACKUP_IN_PROGRESS:
+        return False
+    if status in BACKUP_TERMINAL_FAILURE:
+        raise BackupStateError(f"{describe} reached terminal state {status}: {payload}")
+    raise BackupStateError(f"{describe} reported unknown state {status!r}: {payload}")
+
+
+class Rest:
+    """One principal's REST access to one cluster.
+
+    The owner holds a single httpx.AsyncClient, created lazily inside the running loop and closed by
+    aclose(). pinned() and at() clones share the owner's client and never close it.
+    """
+
+    def __init__(
+        self,
+        base_urls: Sequence[str],
+        api_key: str,
+        label: str,
+        *,
+        connect_timeout_s: float,
+        read_timeout_s: float,
+    ):
+        if not base_urls:
+            raise ValueError(f"[{label}] needs at least one base URL")
+        self.label = label
+        self._base_urls = list(base_urls)
+        self._api_key = api_key
+        self._connect_timeout_s = connect_timeout_s
+        self._read_timeout_s = read_timeout_s
+        self._owner: "Rest | None" = None
+        self._client: httpx.AsyncClient | None = None
+        self._cursor = 0
+        self._pin: int | None = None
+        self._addressed = False
+
+    # --- transport -----------------------------------------------------------
+
+    def _clone(self, suffix: str, pin: int) -> "Rest":
+        owner = self._owner or self
+        clone = Rest(
+            self._base_urls,
+            self._api_key,
+            f"{self.label}@{suffix}",
+            connect_timeout_s=self._connect_timeout_s,
+            read_timeout_s=self._read_timeout_s,
+        )
+        clone._owner = owner
+        clone._pin = pin
+        return clone
+
+    def pinned(self) -> "Rest":
+        """A clone bound to one base URL, sharing this instance's client and pool."""
+        owner = self._owner or self
+        return self._clone("pinned", owner._cursor % len(self._base_urls))
+
+    def at(self, index: int) -> "Rest":
+        """A clone bound to base_urls[index], sharing this instance's client and pool.
+
+        Used where the serving node's own state decides the outcome: authentication against a
+        node's key store, and RBAC enforcement by a node's casbin — role creation and role
+        assignment alike, both of which authorize the caller against local policy. Management reads
+        are leader-routed and rotate instead. Unlike pinned(), this clone never re-pins: the
+        identity of the node is the point, so a dead endpoint fails the call outright.
+        """
+        clone = self._clone(f"node{index}", index % len(self._base_urls))
+        clone._addressed = True
+        return clone
+
+    @property
+    def pinned_url(self) -> str | None:
+        return None if self._pin is None else self._base_urls[self._pin]
+
+    async def aclose(self) -> None:
+        if self._owner is not None:
+            return
+        if self._client is not None:
+            await self._client.aclose()
+            self._client = None
+
+    def _http(self) -> httpx.AsyncClient:
+        owner = self._owner or self
+        if owner._client is None:
+            # trust_env=False mirrors the weaviate client (client-ref/weaviate/config.py:118): an
+            # inherited proxy variable must not reroute traffic aimed at the host's published ports.
+            owner._client = httpx.AsyncClient(
+                headers={"authorization": f"Bearer {owner._api_key}"},
+                trust_env=False,
+            )
+        return owner._client
+
+    def _next_url(self) -> str:
+        if self._pin is not None:
+            return self._base_urls[self._pin]
+        url = self._base_urls[self._cursor % len(self._base_urls)]
+        self._cursor += 1
+        return url
+
+    def _advance(self, reason: str) -> None:
+        # A node-addressed clone never moves: rotating it away would answer the poll from a node
+        # the caller is not asking about.
+        if self._pin is None or self._addressed:
+            return
+        self._pin = (self._pin + 1) % len(self._base_urls)
+        logger.warning(
+            f"[{self.label}] re-pinned to {self._base_urls[self._pin]} after {reason}; "
+            "status now reads from the object store's global descriptor"
+        )
+
+    async def request(
+        self,
+        method: str,
+        path: str,
+        *,
+        json: Any = None,
+        params: dict[str, Any] | None = None,
+        expect: Iterable[int] | _AnyStatus = (200,),
+        read_timeout_s: float | None = None,
+    ) -> httpx.Response:
+        expected = None if isinstance(expect, _AnyStatus) else frozenset(expect)
+        timeout = httpx.Timeout(
+            connect=self._connect_timeout_s,
+            write=self._connect_timeout_s,
+            pool=self._connect_timeout_s,
+            read=self._read_timeout_s if read_timeout_s is None else read_timeout_s,
+        )
+        # Only idempotent methods are retried. A POST that reached the server may have applied
+        # (openapi-specs/schema.json:10302-10307 documents 503 as "may or may not have been
+        # applied"), and every read-side exception below is raised after the request was written.
+        attempts = _RETRY_ATTEMPTS if method in _RETRY_METHODS else 1
+        for attempt in range(1, attempts + 1):
+            url = self._next_url()
+            try:
+                response = await self._http().request(
+                    method, f"{url}{path}", json=json, params=params, timeout=timeout
+                )
+            except (httpx.ConnectError, httpx.ConnectTimeout) as exc:
+                if attempt == attempts:
+                    raise
+                logger.warning(f"[{self.label}] {method} {path} on {url}: {exc!r}, retrying")
+                self._advance(repr(exc))
+                await asyncio.sleep(_RETRY_BACKOFF_S * attempt)
+                continue
+            if expected is not None and response.status_code in expected:
+                return response
+            if response.status_code in _RETRY_STATUSES and attempt < attempts:
+                logger.warning(
+                    f"[{self.label}] {method} {path} on {url} -> {response.status_code}, retrying"
+                )
+                self._advance(f"status {response.status_code}")
+                await asyncio.sleep(_RETRY_BACKOFF_S * attempt)
+                continue
+            # ANY_STATUS is handled after the retry branch, so a probe still benefits from the
+            # 502/503 retry rather than reporting a transient as its result.
+            if expected is None:
+                return response
+            raise RestError(self.label, method, path, response.status_code, response.text)
+        raise AssertionError("unreachable: the retry loop returns or raises on its last attempt")
+
+    async def get(self, path: str, **kwargs: Any) -> httpx.Response:
+        return await self.request("GET", path, **kwargs)
+
+    async def post(self, path: str, **kwargs: Any) -> httpx.Response:
+        return await self.request("POST", path, **kwargs)
+
+    async def delete(self, path: str, **kwargs: Any) -> httpx.Response:
+        return await self.request("DELETE", path, **kwargs)
+
+    # --- cluster ------------------------------------------------------------
+
+    async def meta(self) -> dict[str, Any]:
+        return (await self.get("/v1/meta")).json()
+
+    async def nodes(self) -> list[str]:
+        payload = (await self.get("/v1/nodes")).json()
+        return [node["name"] for node in payload.get("nodes", [])]
+
+    async def nodes_for_class(self, class_name: str, read_timeout_s: float) -> list[dict[str, Any]]:
+        response = await self.get(
+            f"/v1/nodes/{class_name}",
+            params={"output": "verbose"},
+            read_timeout_s=read_timeout_s,
+        )
+        return response.json().get("nodes", [])
+
+    async def schema_class_names(self) -> list[str]:
+        payload = (await self.get("/v1/schema")).json()
+        return [cls["class"] for cls in payload.get("classes") or []]
+
+    async def class_exists(self, class_name: str) -> bool:
+        response = await self.get(f"/v1/schema/{class_name}", expect=(200, 404))
+        return response.status_code == 200
+
+    # --- namespaces ---------------------------------------------------------
+
+    async def create_namespace(self, namespace: str) -> httpx.Response:
+        """201 on create; 409 means the name exists or is still being deleted."""
+        return await self.post(f"/v1/namespaces/{namespace}", expect=(201, 409))
+
+    async def get_namespace(self, namespace: str) -> dict[str, Any] | None:
+        """None when the namespace is gone: gone is absence, never a state."""
+        response = await self.get(f"/v1/namespaces/{namespace}", expect=(200, 404))
+        return None if response.status_code == 404 else response.json()
+
+    async def list_namespaces(self) -> httpx.Response:
+        """404 on this endpoint means namespaces are disabled on this cluster."""
+        return await self.get("/v1/namespaces", expect=(200, 404))
+
+    async def delete_namespace(self, namespace: str) -> None:
+        await self.delete(f"/v1/namespaces/{namespace}", expect=(202,))
+
+    # --- users and roles ----------------------------------------------------
+
+    async def create_db_user(self, user_id: str) -> httpx.Response:
+        """201 carries the new key. 422 is raised before any RAFT command, so a retry is safe."""
+        return await self.post(f"/v1/users/db/{user_id}", expect=(201, 422))
+
+    async def get_db_user(self, user_id: str) -> httpx.Response:
+        """422 means db users are disabled (db_users/handlers_db_users.go:233-234)."""
+        return await self.get(f"/v1/users/db/{user_id}", expect=(200, 404, 422))
+
+    async def list_db_users(self) -> list[dict[str, Any]]:
+        """To a root caller this appends every static API-key user, tagged db_env_user.
+
+        Callers must filter on dbUserType; see dynamic_user_ids and static_user_ids.
+        """
+        return (await self.get("/v1/users/db")).json()
+
+    async def own_info(self) -> httpx.Response:
+        return await self.get("/v1/users/own-info", expect=(200, 401, 403))
+
+    async def create_role(self, name: str, permissions: list[dict[str, Any]]) -> httpx.Response:
+        """201 on create. A 403 is decided by the serving node's own casbin
+        (rbac/manager.go:752-770) and is raised before the upsert
+        (handlers_authz.go:376,379-381), so a retry is safe.
+        """
+        return await self.post(
+            "/v1/authz/roles", json={"name": name, "permissions": permissions}, expect=(201, 403)
+        )
+
+    async def list_roles(self) -> list[str]:
+        payload = (await self.get("/v1/authz/roles")).json()
+        return [role["name"] for role in payload or []]
+
+    async def assign_role(self, user_id: str, roles: list[str]) -> httpx.Response:
+        """200 on assign. A 403 has two causes, both raised before AddRolesForUser
+        (handlers_authz.go:857): the serving node's own casbin not yet holding the caller's grant,
+        and a caller that is not confined to a namespace-local role's namespace
+        (validateLocalRoleAssignment, handlers_authz.go:147-158). Only the first is retryable.
+
+        userType is mandatory on a namespace-enabled cluster (handlers_authz.go:1620-1627).
+        """
+        return await self.post(
+            f"/v1/authz/users/{user_id}/assign",
+            json={"roles": roles, "userType": "db"},
+            expect=(200, 403),
+        )
+
+    async def roles_for_user(self, user_id: str) -> list[str]:
+        # The untyped /roles variant is 410 Gone on a namespaced cluster
+        # (handlers_authz.go:946-949); the typed one is the only form valid on both clusters.
+        payload = (await self.get(f"/v1/authz/users/{user_id}/roles/db")).json()
+        return [role["name"] for role in payload or []]
+
+    # --- backup and restore -------------------------------------------------
+
+    async def backup_create(self, backend: str, body: dict[str, Any]) -> dict[str, Any]:
+        """200, not 201. The response carries the resolved wildcard selection in `classes`."""
+        return (await self.post(f"/v1/backups/{backend}", json=body, expect=(200,))).json()
+
+    async def backup_status(self, backend: str, backup_id: str) -> dict[str, Any]:
+        return (await self.get(f"/v1/backups/{backend}/{backup_id}")).json()
+
+    async def backup_restore(
+        self, backend: str, backup_id: str, body: dict[str, Any]
+    ) -> dict[str, Any]:
+        response = await self.post(
+            f"/v1/backups/{backend}/{backup_id}/restore", json=body, expect=(200,)
+        )
+        return response.json()
+
+    async def restore_status(self, backend: str, backup_id: str) -> dict[str, Any]:
+        return (await self.get(f"/v1/backups/{backend}/{backup_id}/restore")).json()
+
+    async def list_backups(self, backend: str, read_timeout_s: float) -> httpx.Response:
+        """Enumerates the backend, so a dead or misconfigured store surfaces here as 500."""
+        return await self.get(
+            f"/v1/backups/{backend}", expect=(200, 500), read_timeout_s=read_timeout_s
+        )
+
+    # --- replication --------------------------------------------------------
+
+    async def scale_plan(self, class_name: str, replication_factor: int) -> httpx.Response:
+        """Any status is returned; only the caller can say which ones are legal for its call.
+
+        501 is the disabled stub. The live handler answers with whatever the leader query produced,
+        including 500 for a class it cannot find: `failed to execute query: rpc error: code =
+        NotFound desc = could not get replication scale plan: class not found: <Class>`. The
+        preflight probe treats that as proof the live handler answered; graduate.py requires 200.
+        """
+        return await self.get(
+            "/v1/replication/scale",
+            params={"collection": class_name, "replicationFactor": replication_factor},
+            expect=ANY_STATUS,
+        )
+
+    async def scale_apply(self, plan: dict[str, Any]) -> dict[str, Any]:
+        return (await self.post("/v1/replication/scale", json=plan, expect=(200,))).json()
+
+    async def replication_details(self, operation_id: str) -> dict[str, Any]:
+        return (await self.get(f"/v1/replication/replicate/{operation_id}")).json()
+
+    async def replication_ops_for(self, class_name: str) -> list[dict[str, Any]]:
+        response = await self.get(
+            "/v1/replication/replicate/list", params={"collection": class_name}
+        )
+        return response.json() or []
+
+    async def sharding_state(self, class_name: str) -> dict[str, Any]:
+        response = await self.get(
+            "/v1/replication/sharding-state", params={"collection": class_name}
+        )
+        return response.json().get("shardingState") or {}
+
+    # --- objects ------------------------------------------------------------
+
+    async def object_on_node(self, class_name: str, uuid: str, node: str) -> httpx.Response:
+        """The only read that targets one replica, and it names that replica with node_name rather
+        than by addressing its base URL.
+
+        node_name and consistency_level are mutually exclusive (handlers_objects.go:985-987), so no
+        consistency level is ever set here. node_name is honoured only when the shard has more than
+        one read replica (adapters/repos/db/index.go:2031-2040); call this only after sharding state
+        confirms rf=3.
+        """
+        return await self.get(
+            f"/v1/objects/{class_name}/{uuid}",
+            params={"include": "vector", "node_name": node},
+            expect=(200, 404),
+        )
+
+
+def dynamic_user_ids(users: list[dict[str, Any]]) -> list[str]:
+    """Dynamic users are exactly the db_user entries (entities/models/user_type_output.go:44-48)."""
+    return [u["userId"] for u in users if u.get("dbUserType") == "db_user"]
+
+
+def static_user_ids(users: list[dict[str, Any]]) -> list[str]:
+    """The cluster's configured static API-key users, appended to every root-caller response."""
+    return [u["userId"] for u in users if u.get("dbUserType") == "db_env_user"]
+
+
+async def ready(base_url: str, *, connect_timeout_s: float, read_timeout_s: float) -> str | None:
+    """Unauthenticated readiness probe. Returns None when ready, else a reason."""
+    timeout = httpx.Timeout(
+        connect=connect_timeout_s,
+        write=connect_timeout_s,
+        pool=connect_timeout_s,
+        read=read_timeout_s,
+    )
+    async with httpx.AsyncClient(trust_env=False) as client:
+        try:
+            response = await client.get(f"{base_url}/v1/.well-known/ready", timeout=timeout)
+        except httpx.HTTPError as exc:
+            return repr(exc)
+    if response.status_code != 200:
+        return f"status {response.status_code}"
+    return None

--- a/apps/namespace-graduation/run.py
+++ b/apps/namespace-graduation/run.py
@@ -1,0 +1,330 @@
+"""Entrypoint: `python3 run.py preflight` checks the rig, `python3 run.py journey` runs the test."""
+
+import asyncio
+import sys
+from typing import Awaitable, TypeVar
+
+from loguru import logger
+
+import assertions
+import restapi
+import wvclient
+from config import Cluster, Config, ConfigError
+from graduate import create_backup, delete_source_namespace, restore_backup, scale_out
+from load import NeighbourLoad
+from restapi import Rest, RestError, dynamic_user_ids, static_user_ids
+from seed import SourceState, seed_source
+
+MODES = ("preflight", "journey")
+
+T = TypeVar("T")
+
+
+class PreflightError(Exception):
+    """The rig is misconfigured. Every problem found is named, with the knob that fixes it."""
+
+
+def _rest(cfg: Config, cluster: Cluster) -> Rest:
+    return Rest(
+        cluster.http_base_urls,
+        cluster.root_api_key,
+        f"{cluster.label}/root",
+        connect_timeout_s=cfg.rest_connect_timeout_s,
+        read_timeout_s=cfg.rest_read_timeout_s,
+    )
+
+
+async def _checked(problems: list[str], check: str, call: Awaitable[T]) -> T | None:
+    """Turn an unexpected status into a named preflight problem instead of a traceback.
+
+    Every probe here reaches a live cluster over the network, so any of them can answer 500 or, on a
+    misconfigured key, 401/403.
+    """
+    try:
+        return await call
+    except RestError as exc:
+        problems.append(f"{check} could not be checked: {exc}")
+        return None
+
+
+async def preflight(cfg: Config, src_root: Rest, tgt_root: Rest) -> None:
+    """Read-only rig validation. Creates nothing on either cluster."""
+    problems: list[str] = []
+    # A name no collection has, used to make the replica-movement handler answer. Distinct from the
+    # capability-probe classes, whose absence is checked below.
+    scale_probe_class = f"{cfg.collection_prefix}Probe{cfg.run_id.capitalize()}"
+    probe_user = f"probe{cfg.run_id}"
+
+    # Reachability of every configured base URL, unauthenticated.
+    for cluster in (cfg.source, cfg.target):
+        for base_url in cluster.http_base_urls:
+            reason = await restapi.ready(
+                base_url,
+                connect_timeout_s=cfg.rest_connect_timeout_s,
+                read_timeout_s=cfg.rest_read_timeout_s,
+            )
+            if reason is not None:
+                problems.append(f"{cluster.label} {base_url} is not ready: {reason}")
+    if problems:
+        raise PreflightError("; ".join(problems))
+
+    # Version and backup module on both clusters.
+    for cluster, root in ((cfg.source, src_root), (cfg.target, tgt_root)):
+        meta = await _checked(problems, f"{cluster.label} /v1/meta", root.meta())
+        if meta is None:
+            continue
+        if meta.get("version") != cfg.weaviate_version:
+            problems.append(
+                f"{cluster.label} runs version {meta.get('version')}, "
+                f"WEAVIATE_VERSION says {cfg.weaviate_version}"
+            )
+        if f"backup-{cfg.backup_backend}" not in (meta.get("modules") or {}):
+            problems.append(
+                f"{cluster.label} has no backup-{cfg.backup_backend} module — check ENABLE_MODULES"
+            )
+
+    # The namespace flags. A 404 on the list endpoint means namespaces are off.
+    source_namespaces = await _checked(
+        problems, "source /v1/namespaces", src_root.list_namespaces()
+    )
+    if source_namespaces is not None and source_namespaces.status_code != 200:
+        problems.append("source cluster has namespaces disabled — set NAMESPACES_ENABLED=true")
+    target_namespaces = await _checked(
+        problems, "target /v1/namespaces", tgt_root.list_namespaces()
+    )
+    if target_namespaces is not None and target_namespaces.status_code != 404:
+        problems.append(
+            "target cluster has namespaces enabled, so the restore would not strip them — "
+            "unset NAMESPACES_ENABLED on the target"
+        )
+
+    # Replica movement. 501 is the only failing status: it is what the disabled stub answers
+    # (adapters/handlers/rest/replication/handlers_setup.go:35-38). Every other status means the
+    # live handler ran, which is all this probe asks. 500 included: against a class that does not
+    # exist the leader query's NotFound surfaces as `failed to execute query: rpc error: code =
+    # NotFound desc = could not get replication scale plan: class not found: <Class>`, observed on
+    # a healthy rig.
+    scale_probe = await _checked(
+        problems,
+        "target replica movement",
+        tgt_root.scale_plan(scale_probe_class, 1),
+    )
+    if scale_probe is not None:
+        if scale_probe.status_code == 501:
+            problems.append(
+                "target has replica movement disabled — set REPLICA_MOVEMENT_ENABLED=true"
+            )
+        else:
+            logger.info(
+                f"target replica movement probe returned {scale_probe.status_code}: "
+                f"{scale_probe.text}"
+            )
+
+    # RBAC. With RBAC off the role restore is skipped silently while the restore still reports
+    # SUCCESS (adapters/handlers/rest/configure_api.go:761-767; usecases/backup/restorer.go:180).
+    target_roles = await _checked(problems, "target RBAC roles", tgt_root.list_roles())
+    if target_roles is not None:
+        missing = {"admin", "viewer"} - set(target_roles)
+        if missing:
+            problems.append(
+                f"target is missing built-in roles {sorted(missing)} — enable RBAC "
+                "(AUTHORIZATION_RBAC_ENABLED) on the target"
+            )
+
+    # Db users. The same nil-guard skips the user restore silently when disabled; the list
+    # endpoint cannot detect it, since it answers 200 with an empty array.
+    db_user_probe = await _checked(problems, "target db users", tgt_root.get_db_user(probe_user))
+    if db_user_probe is not None and db_user_probe.status_code == 422:
+        problems.append(
+            "target has dynamic db users disabled — set AUTHENTICATION_DB_USERS_ENABLED=true"
+        )
+
+    # Consent for the destructive restore.
+    target_users = await _checked(problems, "target user store", tgt_root.list_db_users())
+    if target_users is not None and target_roles is not None:
+        existing_dynamic = dynamic_user_ids(target_users)
+        existing_custom_roles = sorted(set(target_roles) - assertions.BUILT_IN_ROLES)
+        if (existing_dynamic or existing_custom_roles) and not cfg.allow_target_store_replacement:
+            problems.append(
+                "the restore will DELETE the target's dynamic users "
+                f"{sorted(existing_dynamic)} and custom roles {existing_custom_roles}; "
+                "set ALLOW_TARGET_STORE_REPLACEMENT=true to proceed"
+            )
+
+    # The strip refuses when a stripped user id lands on a static API-key user
+    # (usecases/auth/authorization/rbac/namespace_strip.go:243-245), after a full seed and backup
+    # have been spent.
+    if target_users is not None:
+        collisions = set(static_user_ids(target_users)) & set(cfg.graduating_user_short_names())
+        if collisions:
+            problems.append(
+                f"stripped user ids {sorted(collisions)} collide with the target's static API-key "
+                "users; the restore would refuse — change RUN_ID or the static user names"
+            )
+
+    # Node names and count.
+    source_nodes = await _checked(problems, "source /v1/nodes", src_root.nodes())
+    target_nodes = await _checked(problems, "target /v1/nodes", tgt_root.nodes())
+    if target_nodes is not None and len(target_nodes) != cfg.target_replication_factor:
+        problems.append(
+            f"target has {len(target_nodes)} nodes ({target_nodes}), "
+            f"expected {cfg.target_replication_factor}"
+        )
+    # A subset test, not equality: the restore only needs every node the backup descriptor names to
+    # resolve on the target (usecases/backup/coordinator.go:537-542). Target nodes the backup does
+    # not name take no part in it, which is this rig's shape: source [node1], target [node1, node2,
+    # node3].
+    if source_nodes is not None and target_nodes is not None:
+        unresolvable = sorted(set(source_nodes) - set(target_nodes))
+        if unresolvable and not cfg.restore_node_mapping:
+            mapping = dict(zip(unresolvable, sorted(target_nodes)))
+            problems.append(
+                f"source nodes {unresolvable} do not exist on the target "
+                f"{sorted(target_nodes)}, so the restore would fail to resolve them; "
+                f"set RESTORE_NODE_MAPPING, e.g. {mapping}"
+            )
+
+    # Class names carry RUN_ID, so a hit means RUN_ID was reused — or that a previous run's probe
+    # cleanup failed, which is why the capability-probe classes are in the set.
+    target_classes = await _checked(problems, "target /v1/schema", tgt_root.schema_class_names())
+    if target_classes is not None:
+        this_run = set(cfg.graduating_collection_short_names()) | set(cfg.probe_class_names())
+        reused = sorted(set(target_classes) & this_run)
+        if reused:
+            problems.append(f"target already holds this run's classes {reused} — RUN_ID was reused")
+
+    # Backend liveness. The module check above only proves the module is compiled in.
+    for cluster, root in ((cfg.source, src_root), (cfg.target, tgt_root)):
+        response = await _checked(
+            problems,
+            f"{cluster.label} {cfg.backup_backend} backend",
+            root.list_backups(cfg.backup_backend, cfg.rest_read_timeout_s * 2),
+        )
+        if response is None:
+            continue
+        if response.status_code != 200:
+            problems.append(
+                f"{cluster.label} cannot enumerate the {cfg.backup_backend} backend "
+                f"({response.status_code}: {response.text}) — check BACKUP_S3_ENDPOINT, "
+                "BACKUP_S3_BUCKET and the credentials"
+            )
+
+    # Client reachability, gRPC included. skip_init_checks=False makes connect() run the
+    # unauthenticated gRPC health check, so an unpublished gRPC port fails here, not mid-seed.
+    for cluster in (cfg.source, cfg.target):
+        try:
+            async with wvclient.connected(cluster, cluster.root_api_key, skip_init_checks=False):
+                logger.info(f"{cluster.label} client connected over HTTP and gRPC")
+        except Exception as exc:
+            problems.append(
+                f"{cluster.label} client could not connect ({exc!r}) — check the HTTP and gRPC "
+                "ports the compose file publishes"
+            )
+
+    if problems:
+        raise PreflightError("\n".join(f"  - {problem}" for problem in problems))
+    logger.success("preflight passed")
+
+
+def log_artefact_summary(cfg: Config, state: SourceState | None, backup_id: str | None) -> None:
+    """Reachable on every path, including an abort — the runs that leave the most debris."""
+    logger.info("--- artefacts created by this run ---")
+    logger.info(f"RUN_ID={cfg.run_id} backup_id={backup_id}")
+    if state is None:
+        logger.info("no namespaces were seeded")
+    else:
+        for namespace in state.namespaces:
+            logger.info(
+                f"source namespace {namespace.name}: "
+                f"users {[u.user_id for u in namespace.users]}, "
+                f"role {namespace.role_qualified}, "
+                f"collections {[c.qualified_name for c in namespace.collections]}"
+            )
+        logger.info(
+            "source cleanup: DELETE /v1/namespaces/<ns> for each neighbour above, polled to 404"
+        )
+    # The capability probes create real classes on the target, so a failed probe cleanup leaves
+    # classes the collection list above does not cover.
+    logger.info(
+        "target cleanup: DELETE /v1/schema/<Class> for "
+        f"{cfg.graduating_collection_short_names()}, plus any surviving capability-probe class of "
+        f"{cfg.probe_class_names()}"
+    )
+
+
+async def journey(cfg: Config, src_root: Rest, tgt_root: Rest) -> int:
+    # Pre-initialised so the artefact summary in the inner finally is reachable from every abort,
+    # including one part-way through seeding.
+    state: SourceState | None = None
+    load: NeighbourLoad | None = None
+    backup_id: str | None = None
+    failures = assertions.Failures()
+
+    try:
+        state = await seed_source(cfg, src_root)
+        load = NeighbourLoad(cfg, state)
+        await load.start()
+        graduating_classes = [c.qualified_name for c in state.graduating.collections]
+        backup_id = await create_backup(cfg, src_root, graduating_classes)
+        await restore_backup(cfg, tgt_root, backup_id)
+        async with load.paused():
+            await assertions.assert_neighbour_integrity(
+                cfg, failures, src_root, state, load, "after-restore"
+            )
+        await scale_out(cfg, tgt_root, [c.short_name for c in state.graduating.collections])
+        await delete_source_namespace(cfg, src_root)
+    finally:
+        # The summary has its own finally: stop_and_drain() re-raises a dead load task's exception,
+        # and the abort it reports is exactly when the operator needs the inventory of what this run
+        # left on each cluster.
+        try:
+            if load is not None:
+                await load.stop_and_drain()
+        finally:
+            log_artefact_summary(cfg, state, backup_id)
+
+    # Reaching here means every journey step succeeded, so state and load are set.
+
+    await assertions.assert_migrated_data_per_replica(cfg, failures, tgt_root, state, load)
+    await assertions.assert_migrated_users_behave(cfg, failures, state, load)
+    await assertions.assert_target_user_and_role_sets(failures, tgt_root, state, load)
+    await assertions.assert_no_leakage_of_neighbour_collections(failures, tgt_root, state, load)
+    await assertions.assert_neighbour_integrity(
+        cfg, failures, src_root, state, load, "after-ns-delete"
+    )
+    await assertions.assert_source_post_state(cfg, failures, src_root, state, load)
+
+    if failures:
+        logger.error(f"{len(failures.entries)} assertion failures:\n{failures.render()}")
+        return 1
+    logger.success("namespace graduation verified")
+    return 0
+
+
+async def main(mode: str) -> int:
+    cfg = Config.from_env()
+    logger.info(f"mode={mode} config={cfg.summary()}")
+    src_root, tgt_root = _rest(cfg, cfg.source), _rest(cfg, cfg.target)
+    try:
+        await preflight(cfg, src_root, tgt_root)
+        if mode == "preflight":
+            return 0
+        return await journey(cfg, src_root, tgt_root)
+    finally:
+        await src_root.aclose()
+        await tgt_root.aclose()
+
+
+if __name__ == "__main__":
+    selected = sys.argv[1] if len(sys.argv) > 1 else "journey"
+    if selected not in MODES:
+        logger.error(f"unknown mode {selected!r}, expected one of {MODES}")
+        sys.exit(2)
+    try:
+        sys.exit(asyncio.run(main(selected)))
+    except (ConfigError, PreflightError) as error:
+        logger.error(str(error))
+        sys.exit(1)
+    except Exception as error:
+        logger.exception(f"journey aborted: {error!r}")
+        sys.exit(1)

--- a/apps/namespace-graduation/run.py
+++ b/apps/namespace-graduation/run.py
@@ -73,11 +73,6 @@ async def preflight(cfg: Config, src_root: Rest, tgt_root: Rest) -> None:
         meta = await _checked(problems, f"{cluster.label} /v1/meta", root.meta())
         if meta is None:
             continue
-        if meta.get("version") != cfg.weaviate_version:
-            problems.append(
-                f"{cluster.label} runs version {meta.get('version')}, "
-                f"WEAVIATE_VERSION says {cfg.weaviate_version}"
-            )
         if f"backup-{cfg.backup_backend}" not in (meta.get("modules") or {}):
             problems.append(
                 f"{cluster.label} has no backup-{cfg.backup_backend} module — check ENABLE_MODULES"

--- a/apps/namespace-graduation/seed.py
+++ b/apps/namespace-graduation/seed.py
@@ -1,0 +1,387 @@
+"""Source-cluster bootstrap: namespaces, db users, roles, collections and the initial object set.
+
+Nothing writes to the graduating namespace after this module returns: its clients are closed here and
+only its API keys travel onward, and only to the target.
+"""
+
+import random
+import uuid as uuidlib
+from dataclasses import dataclass, field
+from typing import Any
+
+from loguru import logger
+from weaviate.classes.config import Configure, DataType, Property
+from weaviate.classes.data import DataObject
+
+import wvclient
+from config import Cluster, Config
+from model import ExpectedObject, ExpectedSet
+from restapi import Rest, poll
+
+# Capability classes, decided at seed time and probed behaviourally on the target.
+CAPABILITY_ADMIN = "wildcard-admin"
+CAPABILITY_NARROW = "narrow-reader"
+
+# Deliberately narrow, so the negative probe on the target has something real to be denied. Resources
+# are short: a namespaced caller's role is stored as "{ns}:{role}" with "{ns}:*" resources
+# (test/acceptance/authz/role_mgmt_test.go:95-108).
+NARROW_PERMISSIONS = [
+    {"action": "read_collections", "collections": {"collection": "*"}},
+    {"action": "read_data", "data": {"collection": "*"}},
+]
+
+SEED_BATCH_SIZE = 100
+
+
+class SeedError(Exception):
+    """Seeding failed. Journey steps fail fast."""
+
+
+@dataclass
+class SeededUser:
+    user_id: str
+    short_id: str
+    api_key: str
+    capability: str
+
+
+@dataclass
+class SeededCollection:
+    short_name: str
+    qualified_name: str
+    expected: ExpectedSet
+
+
+@dataclass
+class SeededNamespace:
+    index: int
+    name: str
+    role_short: str
+    role_qualified: str
+    users: list[SeededUser] = field(default_factory=list)
+    collections: list[SeededCollection] = field(default_factory=list)
+
+    @property
+    def admin_user(self) -> SeededUser:
+        return self.users[0]
+
+
+@dataclass
+class SourceState:
+    namespaces: list[SeededNamespace] = field(default_factory=list)
+
+    @property
+    def graduating(self) -> SeededNamespace:
+        return self.namespaces[0]
+
+    @property
+    def neighbours(self) -> list[SeededNamespace]:
+        return self.namespaces[1:]
+
+
+def _observed(response: Any) -> str:
+    """What a bounded retry saw. Never a hardcoded status: a poll's last observation is evidence."""
+    return f"{response.status_code}: {response.text[:300]}"
+
+
+def object_uuid(run_id: str, collection: str, serial: int) -> str:
+    return str(uuidlib.uuid5(uuidlib.NAMESPACE_URL, f"{run_id}/{collection}/{serial}"))
+
+
+def object_properties(collection: str, serial: int) -> dict[str, Any]:
+    return {
+        "name": f"{collection}-{serial}",
+        "payload": f"seeded object {serial} of {collection}",
+        "seq": serial,
+    }
+
+
+async def seed_source(cfg: Config, root: Rest) -> SourceState:
+    """Create every namespace, principal and object on the source. The graduating namespace is first."""
+    state = SourceState()
+    for index in range(1, cfg.namespace_count + 1):
+        state.namespaces.append(await _seed_namespace(cfg, root, index))
+    return state
+
+
+async def _seed_namespace(cfg: Config, root: Rest, index: int) -> SeededNamespace:
+    name = cfg.namespace_name(index)
+    namespace = SeededNamespace(
+        index=index,
+        name=name,
+        role_short=cfg.role_short_name(index),
+        role_qualified=f"{name}:{cfg.role_short_name(index)}",
+    )
+    logger.info(f"seeding namespace {name}")
+
+    # Names carry RUN_ID, so a 409 is a genuine collision — a reused RUN_ID, or a namespace of
+    # that name still being deleted. The two causes are distinguishable only by a message this app
+    # must not parse.
+    response = await root.create_namespace(name)
+    if response.status_code == 409:
+        raise SeedError(
+            f"namespace {name} already exists or is still deleting (409); "
+            f"RUN_ID={cfg.run_id} appears to have been used before"
+        )
+
+    for serial in cfg.user_serials(index):
+        namespace.users.append(await _create_user(cfg, root, name, serial))
+
+    # Every write below is addressed to node 0. The assign handler's subject and role lookups are
+    # leader queries (cluster/raft_rbac_query_endpoints.go:25-51; raft_dynuser_query_endpoints.go:
+    # 23-45), so no node's lag can 404 them, but its authorization is decided by the serving node's
+    # own casbin. Node 0 is the node the key poll in _create_user, the role create below and
+    # wvclient.build_client(index=0) all address, so one node's enforcer decides every seed call.
+    admin = namespace.admin_user
+    # The built-in admin is a global role, so the operator may assign it: validateLocalRoleAssignment
+    # only blocks roles carrying a namespace (handlers_authz.go:147-158).
+    await _assign_role(cfg, root, admin.user_id, ["admin"])
+    # The binding must be applied in RAFT before the admin acts. This poll proves that much and no
+    # more; node 0's enforcer holding the binding is proven separately, by the 403 retry in
+    # _create_role.
+    await _await_role_visible(cfg, root, admin, "admin")
+
+    async with principal_rest(cfg, cfg.source, admin) as admin_rest:
+        await _create_role(cfg, admin_rest, namespace.role_short)
+        # A namespace-local role can only be assigned by a caller confined to its namespace, so
+        # this runs as the namespace admin and not as root: a global operator is refused by design,
+        # which is what stops one namespace's role from reaching another's subjects
+        # (validateLocalRoleAssignment, handlers_authz.go:147-158). Both references are short —
+        # the handler qualifies them against the confined caller's namespace
+        # (QualifyUserIDForLookup at handlers_authz.go:791, resolveAssignableRoles at :819) — and a
+        # short name carries no namespace, so it passes the locality check by construction.
+        for user in namespace.users[1:]:
+            await _assign_role(cfg, admin_rest, user.short_id, [namespace.role_short])
+            # The server stores the role qualified, and this read is issued as root, so the
+            # qualified name is what comes back.
+            await _await_role_visible(cfg, root, user, namespace.role_qualified)
+
+    async with wvclient.connected(cfg.source, admin.api_key) as client:
+        for serial in cfg.collection_serials(index):
+            namespace.collections.append(await _seed_collection(cfg, client, name, serial))
+
+    logger.success(
+        f"seeded {name}: {len(namespace.users)} users, "
+        f"{len(namespace.collections)} collections, role {namespace.role_qualified}"
+    )
+    return namespace
+
+
+class principal_rest:
+    """A short-lived Rest bound to one principal's key. Closed on every exit path."""
+
+    def __init__(self, cfg: Config, cluster: Cluster, user: SeededUser):
+        self._rest = Rest(
+            cluster.http_base_urls,
+            user.api_key,
+            f"{cluster.label}/{user.user_id}",
+            connect_timeout_s=cfg.rest_connect_timeout_s,
+            read_timeout_s=cfg.rest_read_timeout_s,
+        )
+
+    async def __aenter__(self) -> Rest:
+        return self._rest
+
+    async def __aexit__(self, *exc: object) -> None:
+        await self._rest.aclose()
+
+
+async def _create_user(cfg: Config, root: Rest, namespace: str, serial: int) -> SeededUser:
+    short_id = cfg.user_short_name(serial)
+    user_id = f"{namespace}:{short_id}"
+
+    async def attempt() -> tuple[bool, Any]:
+        # A 422 here is raised before any RAFT command is issued
+        # (db_users/handlers_db_users.go:429-431, ahead of CreateUser at :457), so no state can be
+        # half-applied and this deliberate POST retry is safe. The most likely cause is a follower
+        # that has not yet applied the namespace this run created seconds ago.
+        response = await root.create_db_user(user_id)
+        if response.status_code == 201:
+            return True, response.json()["apikey"]
+        return False, _observed(response)
+
+    api_key = await poll(
+        attempt,
+        deadline_s=cfg.raft_visibility_timeout_s,
+        interval_s=cfg.poll_interval_s,
+        describe=f"db user {user_id} to be creatable",
+    )
+
+    user = SeededUser(
+        user_id=user_id,
+        short_id=short_id,
+        api_key=api_key,
+        capability=(CAPABILITY_ADMIN if _is_first_of_namespace(cfg, serial) else CAPABILITY_NARROW),
+    )
+
+    async with principal_rest(cfg, cfg.source, user) as user_rest:
+        # Node-addressed, not rotating: authentication validates the key against the serving node's
+        # own store (apikey/db_users.go:514-526), so this is one of the two reads whose answer
+        # depends on which node serves it. The consumer of this key is
+        # wvclient.build_client(index=0), which addresses node 0; a 200 from any other node would
+        # prove nothing about the node serving the next call.
+        node0 = user_rest.at(0)
+
+        async def recognised() -> tuple[bool, Any]:
+            # A freshly created key transiently 401s on a follower that has not applied it yet.
+            response = await node0.own_info()
+            return response.status_code == 200, response.status_code
+
+        await poll(
+            recognised,
+            deadline_s=cfg.raft_visibility_timeout_s,
+            interval_s=cfg.poll_interval_s,
+            describe=f"key of {user_id} to be recognised",
+        )
+    return user
+
+
+def _is_first_of_namespace(cfg: Config, serial: int) -> bool:
+    return (serial - 1) % cfg.users_per_namespace == 0
+
+
+async def _create_role(cfg: Config, admin_rest: Rest, role_short: str) -> None:
+    """Create the namespace's custom role as its admin principal, retrying the node-local denial."""
+    node0 = admin_rest.at(0)
+
+    async def attempt() -> tuple[bool, Any]:
+        # Authorization is decided by the serving node's own casbin (rbac/manager.go:752-770), which
+        # may not yet hold the admin binding assigned moments ago. _await_role_visible is
+        # leader-routed and cannot see that lag, so only this retry covers it. Retrying the POST is
+        # safe: every 403 exit in createRole runs before the upsert (handlers_authz.go:376,379-381),
+        # so no state is half-applied.
+        response = await node0.create_role(role_short, NARROW_PERMISSIONS)
+        return response.status_code == 201, _observed(response)
+
+    await poll(
+        attempt,
+        deadline_s=cfg.raft_visibility_timeout_s,
+        interval_s=cfg.poll_interval_s,
+        describe=f"role {role_short} to be creatable by the namespace admin",
+    )
+
+
+async def _assign_role(cfg: Config, rest: Rest, user_id: str, roles: list[str]) -> None:
+    """Assign roles on node 0, retrying the node-local denial for as long as a lag can explain it."""
+    node0 = rest.at(0)
+
+    async def attempt() -> tuple[bool, Any]:
+        # Same rationale as the retry in _create_role: the caller's own grant is enforced by the
+        # serving node's casbin (rbac/manager.go:752-770), which may not yet hold a binding written
+        # moments ago, and every 403 exit runs before AddRolesForUser (handlers_authz.go:857), so
+        # no state can be half-applied. A denial that outlives the deadline is not a lag — most
+        # likely the caller is not confined to the role's namespace — and its body says so.
+        response = await node0.assign_role(user_id, roles)
+        return response.status_code == 200, _observed(response)
+
+    await poll(
+        attempt,
+        deadline_s=cfg.raft_visibility_timeout_s,
+        interval_s=cfg.poll_interval_s,
+        describe=f"roles {roles} to be assignable to {user_id} by [{rest.label}]",
+    )
+
+
+async def _await_role_visible(cfg: Config, root: Rest, user: SeededUser, role: str) -> None:
+    async def visible() -> tuple[bool, Any]:
+        # A leader query (cluster/raft_rbac_query_endpoints.go:82-110), so one rotating read settles
+        # the binding cluster-wide. It proves nothing about any node's enforcer; the 403 retry in
+        # _create_role is what covers that.
+        names = await root.roles_for_user(user.user_id)
+        return role in names, names
+
+    await poll(
+        visible,
+        deadline_s=cfg.raft_visibility_timeout_s,
+        interval_s=cfg.poll_interval_s,
+        describe=f"role {role} to be visible on {user.user_id}",
+    )
+
+
+async def _seed_collection(
+    cfg: Config, client: Any, namespace: str, serial: int
+) -> SeededCollection:
+    short_name = cfg.collection_short_name(serial)
+    seeded = SeededCollection(
+        short_name=short_name,
+        qualified_name=f"{namespace}:{short_name}",
+        expected=ExpectedSet(collection=short_name),
+    )
+    # Short names auto-qualify server-side for a namespace-bound principal. The source caps the
+    # replication factor at 1 regardless of what is asked for.
+    await client.collections.create(
+        name=short_name,
+        properties=[
+            Property(name="name", data_type=DataType.TEXT),
+            Property(name="payload", data_type=DataType.TEXT),
+            Property(name="seq", data_type=DataType.INT),
+        ],
+        vector_config=Configure.Vectors.self_provided(),
+        replication_config=Configure.replication(factor=1),
+    )
+
+    collection = client.collections.use(short_name)
+    rng = random.Random(f"{cfg.run_id}/{short_name}")
+    pending: list[DataObject] = []
+    expected_batch: list[ExpectedObject] = []
+    for index in range(cfg.objects_per_collection):
+        obj_uuid = object_uuid(cfg.run_id, short_name, index)
+        properties = object_properties(short_name, index)
+        vector = wvclient.random_vector(rng, cfg.vector_dim)
+        pending.append(
+            DataObject(
+                properties=properties,
+                uuid=obj_uuid,
+                vector={wvclient.VECTOR_NAME: vector},
+            )
+        )
+        expected_batch.append(
+            ExpectedObject(
+                uuid=obj_uuid,
+                properties=properties,
+                vectors={wvclient.VECTOR_NAME: vector},
+            )
+        )
+        if len(pending) == SEED_BATCH_SIZE:
+            await _insert_batch(collection, pending, expected_batch, seeded)
+            pending, expected_batch = [], []
+    if pending:
+        await _insert_batch(collection, pending, expected_batch, seeded)
+
+    actual = await wvclient.read_all(collection)
+    diffs = seeded.expected.diff(actual)
+    if diffs:
+        raise SeedError(
+            f"seed of {seeded.qualified_name} did not land: "
+            + "; ".join(diff.render() for diff in diffs[:20])
+        )
+    logger.info(f"seeded {seeded.qualified_name} with {len(seeded.expected)} objects")
+    return seeded
+
+
+async def _insert_batch(
+    collection: Any,
+    pending: list[DataObject],
+    expected_batch: list[ExpectedObject],
+    seeded: SeededCollection,
+) -> None:
+    try:
+        result = await collection.data.insert_many(pending)
+    except Exception as exc:
+        # An all-fail batch raises WeaviateInsertManyAllFailedError instead of returning.
+        raise SeedError(_batch_failure(seeded, wvclient.usage_limit_rejection(exc), exc)) from exc
+    # A partial failure returns normally, so the errors map is inspected on every batch.
+    if result.has_errors:
+        limit = wvclient.usage_limit_in_batch_errors(result.errors)
+        raise SeedError(_batch_failure(seeded, limit, result.errors))
+    for obj in expected_batch:
+        seeded.expected.record_insert(obj)
+
+
+def _batch_failure(seeded: SeededCollection, limit: str | None, detail: Any) -> str:
+    if limit is not None:
+        return (
+            "the rig's MAXIMUM_ALLOWED_OBJECTS_COUNT is below what this run needs "
+            f"(seeding {seeded.qualified_name}): {limit}"
+        )
+    return f"seeding {seeded.qualified_name} failed: {detail}"

--- a/apps/namespace-graduation/wvclient.py
+++ b/apps/namespace-graduation/wvclient.py
@@ -1,0 +1,98 @@
+"""weaviate-client v4.22.0 construction and the usage rules the pinned tag imposes."""
+
+import random
+from contextlib import asynccontextmanager
+from typing import Any, AsyncIterator
+
+import weaviate
+from weaviate.classes.init import Auth
+from weaviate.client import WeaviateAsyncClient
+from weaviate.exceptions import InsufficientPermissionsError, UnexpectedStatusCodeError
+
+from config import Cluster
+from model import ExpectedObject
+
+# Configure.Vectors.self_provided() creates a named vector called "default"
+# (client-ref/weaviate/collections/classes/config.py:2496-2501). On such a collection the server
+# rejects a legacy top-level "vector", so every write sends {VECTOR_NAME: [...]} and every read asks
+# for include_vector=True — a bare name string silently returns no vector (classes/grpc.py:147-160).
+VECTOR_NAME = "default"
+
+# usecases/usagelimits/errors.go:31-43
+USAGE_LIMIT_ERROR_CODE = "USAGE_LIMIT_EXCEEDED"
+
+
+def build_client(
+    cluster: Cluster, api_key: str, *, index: int = 0, skip_init_checks: bool = True
+) -> WeaviateAsyncClient:
+    """Build (but do not connect) an async client against one node of a cluster.
+
+    There is no async connect_to_custom at this tag; the factory only builds, and connect() is
+    mandatory before any other call (client-ref/weaviate/connect/helpers.py:579-660).
+    """
+    return weaviate.use_async_with_custom(
+        http_host=cluster.host,
+        http_port=cluster.http_port(index),
+        http_secure=False,
+        grpc_host=cluster.host,
+        grpc_port=cluster.grpc_port(index),
+        grpc_secure=False,
+        auth_credentials=Auth.api_key(api_key),
+        skip_init_checks=skip_init_checks,
+    )
+
+
+@asynccontextmanager
+async def connected(
+    cluster: Cluster, api_key: str, *, index: int = 0, skip_init_checks: bool = True
+) -> AsyncIterator[WeaviateAsyncClient]:
+    client = build_client(cluster, api_key, index=index, skip_init_checks=skip_init_checks)
+    await client.connect()
+    try:
+        yield client
+    finally:
+        await client.close()
+
+
+def is_permission_denied(exc: BaseException) -> bool:
+    """403 on REST paths, gRPC code 7 on gRPC paths. Both raise InsufficientPermissionsError."""
+    return isinstance(exc, InsufficientPermissionsError) and exc.status_code in (403, 7)
+
+
+def usage_limit_rejection(exc: BaseException) -> str | None:
+    """The rig's MAXIMUM_ALLOWED_OBJECTS_COUNT was hit. Returns the server's payload, else None.
+
+    Surfaces as HTTP 429 or gRPC RESOURCE_EXHAUSTED, both carrying errorCode USAGE_LIMIT_EXCEEDED.
+    Matched on the machine-readable error code, never on prose.
+    """
+    text = str(exc)
+    if USAGE_LIMIT_ERROR_CODE in text:
+        return text
+    if isinstance(exc, UnexpectedStatusCodeError) and exc.status_code == 429:
+        return text
+    return None
+
+
+def usage_limit_in_batch_errors(errors: dict[Any, Any]) -> str | None:
+    """insert_many reports per-object failures rather than raising; inspect them the same way."""
+    for error in errors.values():
+        message = getattr(error, "message", str(error))
+        if USAGE_LIMIT_ERROR_CODE in message:
+            return message
+    return None
+
+
+def random_vector(rng: random.Random, dim: int) -> list[float]:
+    return [rng.uniform(-1.0, 1.0) for _ in range(dim)]
+
+
+async def read_all(collection: Any) -> dict[str, ExpectedObject]:
+    """Read a whole collection through the client, vectors included, keyed by uuid."""
+    out: dict[str, ExpectedObject] = {}
+    async for obj in collection.iterator(include_vector=True):
+        out[str(obj.uuid)] = ExpectedObject(
+            uuid=str(obj.uuid),
+            properties=dict(obj.properties),
+            vectors={name: list(values) for name, values in (obj.vector or {}).items()},
+        )
+    return out

--- a/apps/weaviate/docker-compose-namespaces-source.yml
+++ b/apps/weaviate/docker-compose-namespaces-source.yml
@@ -1,0 +1,106 @@
+---
+# Namespaced source cluster for namespace_graduation.sh, plus the minio both clusters back up to.
+# Single node, so the backup descriptor names only `node1` — the name the target also carries, which
+# is what lets the restore resolve every descriptor node without a node_mapping.
+#
+# Brought up as compose project `nsgrad-src` by namespace_graduation.sh, which also creates the
+# external `nsgrad-shared` network. Storage is named volumes, not $PWD bind mounts, so that
+# `docker compose down -v` cleans up without privilege.
+services:
+  weaviate:
+    init: true
+    command:
+    - --host
+    - 0.0.0.0
+    - --port
+    - '8080'
+    - --scheme
+    - http
+    - --write-timeout
+    - 600s
+    image: semitechnologies/weaviate:$WEAVIATE_VERSION
+    ports:
+    - 18080:8080
+    - 18090:50051
+    restart: on-failure:0
+    volumes:
+    - nsgrad-src-node-1:/var/lib/weaviate
+    environment:
+      ASYNC_INDEXING: '${ASYNC_INDEXING:-true}'
+      QUERY_DEFAULTS_LIMIT: 25
+      PERSISTENCE_DATA_PATH: '/var/lib/weaviate'
+      DEBUG_ENDPOINTS_ENABLED: 'true'
+      DEFAULT_VECTORIZER_MODULE: 'none'
+      DISABLE_TELEMETRY: 'true'
+      LOG_LEVEL: '${LOG_LEVEL:-debug}'
+      CLUSTER_HOSTNAME: 'node1'
+      # RBAC is meaningless with anonymous access on, and NAMESPACES_ENABLED requires RBAC.
+      AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED: 'false'
+      AUTHENTICATION_APIKEY_ENABLED: 'true'
+      # namespace_graduation.sh exports this, defaulted; config.py's SOURCE_ROOT_API_KEY must match.
+      AUTHENTICATION_APIKEY_ALLOWED_KEYS: '${SOURCE_ROOT_API_KEY}'
+      AUTHENTICATION_APIKEY_USERS: 'root-user'
+      AUTHORIZATION_RBAC_ENABLED: 'true'
+      AUTHORIZATION_RBAC_ROOT_USERS: 'root-user'
+      # Namespace-bound principals are dynamic db users.
+      AUTHENTICATION_DB_USERS_ENABLED: 'true'
+      NAMESPACES_ENABLED: 'true'
+      # NAMESPACES_ENABLED refuses to start without DISABLE_GRAPHQL=true
+      # (usecases/config/config_handler.go:392-394).
+      DISABLE_GRAPHQL: 'true'
+      # Also a hard startup requirement of NAMESPACES_ENABLED: startup refuses any other value
+      # (adapters/handlers/rest/configure_api.go:1249-1252), because a namespace's shards are pinned
+      # to one home_node. The cap is what holds every source collection at rf=1, which is the
+      # configuration the graduation scales out of.
+      REPLICATION_MAXIMUM_FACTOR: '1'
+      ENABLE_MODULES: 'backup-s3'
+      # Identical to the target file's block: the handover needs both clusters on one bucket.
+      BACKUP_S3_ENDPOINT: 'nsgrad-minio:9000'
+      BACKUP_S3_BUCKET: 'nsgrad-backups'
+      BACKUP_S3_USE_SSL: 'false'
+      AWS_ACCESS_KEY_ID: 'aws_access_key'
+      AWS_SECRET_KEY: 'aws_secret_key'
+    networks:
+    - nsgrad-shared
+
+  # Unpublished: only the two clusters talk to it, and an unpublished port cannot collide with
+  # another test's minio. The target reaches it under the `nsgrad-minio` alias.
+  minio:
+    image: minio/minio
+    command: server /data
+    volumes:
+    - nsgrad-minio:/data
+    environment:
+      MINIO_ROOT_USER: 'aws_access_key'
+      MINIO_ROOT_PASSWORD: 'aws_secret_key'
+    networks:
+      nsgrad-shared:
+        aliases:
+        - nsgrad-minio
+
+  # The exit code is the bucket's: `mc alias set` is retried until minio answers, and neither step
+  # is followed by `exit 0`. namespace_graduation.sh waits on that code before starting the app,
+  # so a bucket that was never created fails the run here instead of as a 500 mid-preflight.
+  create-s3-bucket:
+    image: minio/mc
+    depends_on:
+    - minio
+    entrypoint: >
+      /bin/sh -c "
+      until /usr/bin/mc alias set nsgrad http://nsgrad-minio:9000 aws_access_key aws_secret_key;
+      do echo 'waiting for minio'; sleep 1; done;
+      /usr/bin/mc mb --ignore-existing nsgrad/nsgrad-backups;
+      "
+    networks:
+    - nsgrad-shared
+
+volumes:
+  nsgrad-src-node-1:
+  nsgrad-minio:
+
+networks:
+  # Created and removed by namespace_graduation.sh. External in both files so that neither compose
+  # project owns it and the two projects' containers can resolve each other.
+  nsgrad-shared:
+    external: true
+...

--- a/apps/weaviate/docker-compose-namespaces-target.yml
+++ b/apps/weaviate/docker-compose-namespaces-target.yml
@@ -1,0 +1,172 @@
+---
+# Non-namespaced 3-node target cluster for namespace_graduation.sh: the cluster the graduating
+# namespace lands on. NAMESPACES_ENABLED is absent on purpose — the restore strips the `<ns>:`
+# prefix from classes, users and roles exactly when the restoring cluster has namespaces off.
+#
+# Brought up as compose project `nsgrad-tgt`. It joins the external `nsgrad-shared` network created
+# by the script, which is how it reaches the source project's minio under the `nsgrad-minio` alias.
+services:
+  weaviate-node-1:
+    init: true
+    command:
+    - --host
+    - 0.0.0.0
+    - --port
+    - '8080'
+    - --scheme
+    - http
+    - --write-timeout
+    - 600s
+    image: semitechnologies/weaviate:$WEAVIATE_VERSION
+    ports:
+    - 18180:8080
+    - 18190:50051
+    restart: on-failure:0
+    volumes:
+    - nsgrad-tgt-node-1:/var/lib/weaviate
+    environment:
+      ASYNC_INDEXING: '${ASYNC_INDEXING:-true}'
+      QUERY_DEFAULTS_LIMIT: 25
+      PERSISTENCE_DATA_PATH: '/var/lib/weaviate'
+      DEBUG_ENDPOINTS_ENABLED: 'true'
+      DEFAULT_VECTORIZER_MODULE: 'none'
+      DISABLE_TELEMETRY: 'true'
+      LOG_LEVEL: '${LOG_LEVEL:-debug}'
+      # node1 exists on both clusters, so every node the backup descriptor names resolves here
+      # (usecases/backup/coordinator.go:537-542) and the restore needs no node_mapping.
+      CLUSTER_HOSTNAME: 'node1'
+      CLUSTER_GOSSIP_BIND_PORT: '7100'
+      CLUSTER_DATA_BIND_PORT: '7101'
+      RAFT_JOIN: 'node1,node2,node3'
+      RAFT_BOOTSTRAP_EXPECT: 3
+      AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED: 'false'
+      AUTHENTICATION_APIKEY_ENABLED: 'true'
+      # Deliberately not the source's key: a mis-addressed call must fail, not land on the wrong
+      # cluster. namespace_graduation.sh exports it, defaulted.
+      AUTHENTICATION_APIKEY_ALLOWED_KEYS: '${TARGET_ROOT_API_KEY}'
+      AUTHENTICATION_APIKEY_USERS: 'root-user'
+      # RBAC and db users must both be on, or the restore skips roles and users silently while
+      # still reporting SUCCESS (usecases/backup/restorer.go:169,180).
+      AUTHORIZATION_RBAC_ENABLED: 'true'
+      AUTHORIZATION_RBAC_ROOT_USERS: 'root-user'
+      AUTHENTICATION_DB_USERS_ENABLED: 'true'
+      # Defaults to false (usecases/config/environment.go:1408-1410), and every /v1/replication/*
+      # handler is a 501 stub without it (adapters/handlers/rest/replication/handlers_setup.go:35-38).
+      # No REPLICATION_MAXIMUM_FACTOR here, so the migrated collections can reach rf=3.
+      REPLICA_MOVEMENT_ENABLED: 'true'
+      ENABLE_MODULES: 'backup-s3'
+      BACKUP_S3_ENDPOINT: 'nsgrad-minio:9000'
+      BACKUP_S3_BUCKET: 'nsgrad-backups'
+      BACKUP_S3_USE_SSL: 'false'
+      AWS_ACCESS_KEY_ID: 'aws_access_key'
+      AWS_SECRET_KEY: 'aws_secret_key'
+    networks:
+    - nsgrad-shared
+
+  weaviate-node-2:
+    init: true
+    command:
+    - --host
+    - 0.0.0.0
+    - --port
+    - '8080'
+    - --scheme
+    - http
+    - --write-timeout
+    - 600s
+    image: semitechnologies/weaviate:$WEAVIATE_VERSION
+    ports:
+    - 18181:8080
+    - 18191:50051
+    restart: on-failure:0
+    volumes:
+    - nsgrad-tgt-node-2:/var/lib/weaviate
+    environment:
+      ASYNC_INDEXING: '${ASYNC_INDEXING:-true}'
+      QUERY_DEFAULTS_LIMIT: 25
+      PERSISTENCE_DATA_PATH: '/var/lib/weaviate'
+      DEBUG_ENDPOINTS_ENABLED: 'true'
+      DEFAULT_VECTORIZER_MODULE: 'none'
+      DISABLE_TELEMETRY: 'true'
+      LOG_LEVEL: '${LOG_LEVEL:-debug}'
+      CLUSTER_HOSTNAME: 'node2'
+      CLUSTER_GOSSIP_BIND_PORT: '7102'
+      CLUSTER_DATA_BIND_PORT: '7103'
+      CLUSTER_JOIN: 'weaviate-node-1:7100'
+      RAFT_JOIN: 'node1,node2,node3'
+      RAFT_BOOTSTRAP_EXPECT: 3
+      AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED: 'false'
+      AUTHENTICATION_APIKEY_ENABLED: 'true'
+      AUTHENTICATION_APIKEY_ALLOWED_KEYS: '${TARGET_ROOT_API_KEY}'
+      AUTHENTICATION_APIKEY_USERS: 'root-user'
+      AUTHORIZATION_RBAC_ENABLED: 'true'
+      AUTHORIZATION_RBAC_ROOT_USERS: 'root-user'
+      AUTHENTICATION_DB_USERS_ENABLED: 'true'
+      REPLICA_MOVEMENT_ENABLED: 'true'
+      ENABLE_MODULES: 'backup-s3'
+      BACKUP_S3_ENDPOINT: 'nsgrad-minio:9000'
+      BACKUP_S3_BUCKET: 'nsgrad-backups'
+      BACKUP_S3_USE_SSL: 'false'
+      AWS_ACCESS_KEY_ID: 'aws_access_key'
+      AWS_SECRET_KEY: 'aws_secret_key'
+    networks:
+    - nsgrad-shared
+
+  weaviate-node-3:
+    init: true
+    command:
+    - --host
+    - 0.0.0.0
+    - --port
+    - '8080'
+    - --scheme
+    - http
+    - --write-timeout
+    - 600s
+    image: semitechnologies/weaviate:$WEAVIATE_VERSION
+    ports:
+    - 18182:8080
+    - 18192:50051
+    restart: on-failure:0
+    volumes:
+    - nsgrad-tgt-node-3:/var/lib/weaviate
+    environment:
+      ASYNC_INDEXING: '${ASYNC_INDEXING:-true}'
+      QUERY_DEFAULTS_LIMIT: 25
+      PERSISTENCE_DATA_PATH: '/var/lib/weaviate'
+      DEBUG_ENDPOINTS_ENABLED: 'true'
+      DEFAULT_VECTORIZER_MODULE: 'none'
+      DISABLE_TELEMETRY: 'true'
+      LOG_LEVEL: '${LOG_LEVEL:-debug}'
+      CLUSTER_HOSTNAME: 'node3'
+      CLUSTER_GOSSIP_BIND_PORT: '7104'
+      CLUSTER_DATA_BIND_PORT: '7105'
+      CLUSTER_JOIN: 'weaviate-node-1:7100'
+      RAFT_JOIN: 'node1,node2,node3'
+      RAFT_BOOTSTRAP_EXPECT: 3
+      AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED: 'false'
+      AUTHENTICATION_APIKEY_ENABLED: 'true'
+      AUTHENTICATION_APIKEY_ALLOWED_KEYS: '${TARGET_ROOT_API_KEY}'
+      AUTHENTICATION_APIKEY_USERS: 'root-user'
+      AUTHORIZATION_RBAC_ENABLED: 'true'
+      AUTHORIZATION_RBAC_ROOT_USERS: 'root-user'
+      AUTHENTICATION_DB_USERS_ENABLED: 'true'
+      REPLICA_MOVEMENT_ENABLED: 'true'
+      ENABLE_MODULES: 'backup-s3'
+      BACKUP_S3_ENDPOINT: 'nsgrad-minio:9000'
+      BACKUP_S3_BUCKET: 'nsgrad-backups'
+      BACKUP_S3_USE_SSL: 'false'
+      AWS_ACCESS_KEY_ID: 'aws_access_key'
+      AWS_SECRET_KEY: 'aws_secret_key'
+    networks:
+    - nsgrad-shared
+
+volumes:
+  nsgrad-tgt-node-1:
+  nsgrad-tgt-node-2:
+  nsgrad-tgt-node-3:
+
+networks:
+  nsgrad-shared:
+    external: true
+...

--- a/namespace_graduation.sh
+++ b/namespace_graduation.sh
@@ -17,8 +17,8 @@ set -euo pipefail
 
 MODE="${1:-journey}"
 
-# Both compose files interpolate this into their image tag, and the app re-asserts it against
-# /v1/meta in preflight.
+# Both compose files interpolate this into their image tag; the app receives the same value and
+# records it in its config summary.
 : "${WEAVIATE_VERSION:?set WEAVIATE_VERSION, e.g. WEAVIATE_VERSION=1.38.0 ./namespace_graduation.sh}"
 
 # The one home for the static root keys: the compose files interpolate them into

--- a/namespace_graduation.sh
+++ b/namespace_graduation.sh
@@ -1,0 +1,216 @@
+#!/usr/bin/env bash
+# Namespace graduation e2e: backup one namespace off a shared namespaced cluster, restore it onto a
+# dedicated 3-node cluster, scale rf=1->3, delete the source namespace, then assert the migration.
+#
+# This script owns the rig: both clusters are its own compose projects, provisioned here.
+#
+# common.sh is deliberately NOT sourced: its shutdown() removes every container on the machine and
+# deletes apps/weaviate/data*, and it is wired to an unconditional EXIT trap. The readiness poll and
+# the teardown below are the two pieces of it this script needs, scoped to its own two projects.
+#
+# Usage (from the repo root):
+#   WEAVIATE_VERSION=1.38.0 ./namespace_graduation.sh            # full journey
+#   WEAVIATE_VERSION=1.38.0 ./namespace_graduation.sh preflight   # rig check only
+#   KEEP_CLUSTERS=1 WEAVIATE_VERSION=1.38.0 ./namespace_graduation.sh   # leave both clusters up
+
+set -euo pipefail
+
+MODE="${1:-journey}"
+
+# Both compose files interpolate this into their image tag, and the app re-asserts it against
+# /v1/meta in preflight.
+: "${WEAVIATE_VERSION:?set WEAVIATE_VERSION, e.g. WEAVIATE_VERSION=1.38.0 ./namespace_graduation.sh}"
+
+# The one home for the static root keys: the compose files interpolate them into
+# AUTHENTICATION_APIKEY_ALLOWED_KEYS and the app container receives the same values.
+export SOURCE_ROOT_API_KEY="${SOURCE_ROOT_API_KEY:-nsgrad-source-root-key}"
+export TARGET_ROOT_API_KEY="${TARGET_ROOT_API_KEY:-nsgrad-target-root-key}"
+
+SRC_FILE="apps/weaviate/docker-compose-namespaces-source.yml"
+SRC_PROJECT="nsgrad-src"
+TGT_FILE="apps/weaviate/docker-compose-namespaces-target.yml"
+TGT_PROJECT="nsgrad-tgt"
+NETWORK="nsgrad-shared"
+
+KEEP_CLUSTERS="${KEEP_CLUSTERS:-0}"
+READY_TIMEOUT_S="${READY_TIMEOUT_S:-180}"
+
+# Host ports the two compose files publish. config.py defaults to the same ones.
+SRC_HTTP_PORTS="18080"
+TGT_HTTP_PORTS="18180 18181 18182"
+
+dump_service_logs() {
+  local project=$1
+  local file=$2
+  local service=$3
+  echo "===== ${project}/${service}: first 30 lines ====="
+  docker compose -p "$project" -f "$file" logs --no-color --no-log-prefix "$service" 2>&1 | head -30 || true
+  echo "===== ${project}/${service}: last 100 lines ====="
+  docker compose -p "$project" -f "$file" logs --no-color --no-log-prefix --tail 100 "$service" 2>&1 || true
+}
+
+# Runs before teardown on a failure: `down -v` destroys the containers, so the evidence has to
+# reach the run log first. The app container's own output is already streamed by `docker logs -ft`.
+dump_cluster_logs() {
+  echo "Dumping cluster logs before teardown"
+  dump_service_logs "$SRC_PROJECT" "$SRC_FILE" weaviate
+  local service
+  for service in weaviate-node-1 weaviate-node-2 weaviate-node-3; do
+    dump_service_logs "$TGT_PROJECT" "$TGT_FILE" "$service"
+  done
+}
+
+# `down -v` removes the named volumes with the containers, so consecutive runs start from empty
+# clusters and no stale RAFT state survives. The network is removed last: both projects reference
+# it as external, so it can only go once nothing is attached.
+compose_down() {
+  docker compose -p "$TGT_PROJECT" -f "$TGT_FILE" down -v --remove-orphans || true
+  docker compose -p "$SRC_PROJECT" -f "$SRC_FILE" down -v --remove-orphans || true
+  docker network rm "$NETWORK" >/dev/null 2>&1 || true
+}
+
+teardown() {
+  local code=$?
+  trap - EXIT
+  if [ "$code" -ne 0 ]; then
+    dump_cluster_logs
+  fi
+  if [ "$KEEP_CLUSTERS" = "1" ]; then
+    echo "KEEP_CLUSTERS=1 — leaving projects ${SRC_PROJECT} and ${TGT_PROJECT} up"
+    exit "$code"
+  fi
+  echo "Tearing down both clusters"
+  compose_down
+  exit "$code"
+}
+
+wait_ready() {
+  local port=$1
+  local waited=0
+  until curl -sf "http://localhost:${port}/v1/.well-known/ready" >/dev/null; do
+    if [ "$waited" -ge "$READY_TIMEOUT_S" ]; then
+      echo "port ${port} never became ready within ${READY_TIMEOUT_S}s"
+      exit 1
+    fi
+    sleep 2
+    waited=$((waited + 2))
+  done
+  echo "port ${port} is ready"
+}
+
+# The bucket one-shot is a readiness gate, not a fire-and-forget: until it has exited 0 the bucket
+# may not exist, and the app's first backend call then answers 500 "The specified bucket does not
+# exist". Both modes pass through here, so preflight gets the same guarantee as the journey.
+wait_bucket() {
+  local waited=0
+  local container_id
+  container_id=$(docker compose -p "$SRC_PROJECT" -f "$SRC_FILE" ps -aq create-s3-bucket)
+  if [ -z "$container_id" ]; then
+    echo "the create-s3-bucket container was never created — the backup bucket does not exist"
+    exit 1
+  fi
+  while true; do
+    local state
+    local code
+    state=$(docker inspect -f '{{.State.Status}}' "$container_id")
+    code=$(docker inspect -f '{{.State.ExitCode}}' "$container_id")
+    if [ "$state" = "exited" ]; then
+      if [ "$code" = "0" ]; then
+        echo "backup bucket nsgrad-backups is ready"
+        return 0
+      fi
+      echo "create-s3-bucket exited ${code}: the backup bucket was not created"
+      docker logs "$container_id" 2>&1 || true
+      exit 1
+    fi
+    if [ "$waited" -ge "$READY_TIMEOUT_S" ]; then
+      echo "create-s3-bucket did not finish within ${READY_TIMEOUT_S}s (state ${state})"
+      docker logs "$container_id" 2>&1 || true
+      exit 1
+    fi
+    sleep 2
+    waited=$((waited + 2))
+  done
+}
+
+echo "Building the namespace-graduation container"
+(cd apps/namespace-graduation && docker build -t namespace_graduation .)
+
+# Pre-clean before the trap is installed: an aborted previous run can leave containers and volumes
+# behind, and a reused volume carries RAFT state from a cluster that no longer exists.
+echo "Removing anything left behind by a previous run"
+compose_down
+
+echo "Creating the ${NETWORK} network"
+docker network inspect "$NETWORK" >/dev/null 2>&1 || docker network create "$NETWORK" >/dev/null
+
+trap teardown EXIT
+
+echo "Starting the namespaced source cluster and minio"
+docker compose -p "$SRC_PROJECT" -f "$SRC_FILE" up -d weaviate minio
+
+echo "Creating the backup bucket"
+docker compose -p "$SRC_PROJECT" -f "$SRC_FILE" up create-s3-bucket
+
+echo "Starting the 3-node target cluster"
+docker compose -p "$TGT_PROJECT" -f "$TGT_FILE" up -d
+
+# Every target node, not just the first: RAFT_BOOTSTRAP_EXPECT is 3, so the target has no leader
+# until all three are up.
+for port in $SRC_HTTP_PORTS $TGT_HTTP_PORTS; do
+  wait_ready "$port"
+done
+
+wait_bucket
+
+echo "Starting ${MODE}"
+# The app reaches both clusters through their published host ports, via host.docker.internal.
+# --network host is not used: on Docker Desktop for macOS it does not reach published ports.
+container_id=$(docker run -d --add-host=host.docker.internal:host-gateway \
+  -e WEAVIATE_VERSION \
+  -e RUN_ID \
+  -e WEAVIATE_HOST_ADDR \
+  -e SOURCE_ROOT_API_KEY \
+  -e TARGET_ROOT_API_KEY \
+  -e SOURCE_HTTP_PORTS \
+  -e SOURCE_GRPC_PORTS \
+  -e TARGET_HTTP_PORTS \
+  -e TARGET_GRPC_PORTS \
+  -e NAMESPACE_PREFIX \
+  -e NEIGHBOUR_NAMESPACE_COUNT \
+  -e COLLECTION_PREFIX \
+  -e COLLECTIONS_PER_NAMESPACE \
+  -e OBJECTS_PER_COLLECTION \
+  -e VECTOR_DIM \
+  -e USERS_PER_NAMESPACE \
+  -e NEIGHBOUR_SET_TARGET \
+  -e BACKUP_BACKEND \
+  -e BACKUP_ID_PREFIX \
+  -e TARGET_REPLICATION_FACTOR \
+  -e ALLOW_TARGET_STORE_REPLACEMENT \
+  -e POLL_INTERVAL_S \
+  -e REST_CONNECT_TIMEOUT_S \
+  -e REST_READ_TIMEOUT_S \
+  -e RAFT_VISIBILITY_TIMEOUT_S \
+  -e BACKUP_TIMEOUT_S \
+  -e RESTORE_TIMEOUT_S \
+  -e SCALE_OP_TIMEOUT_S \
+  -e SHARDING_STATE_TIMEOUT_S \
+  -e NAMESPACE_DELETE_TIMEOUT_S \
+  -e PER_REPLICA_SWEEP_TIMEOUT_S \
+  -e PER_REPLICA_SWEEP_CONCURRENCY \
+  -e COUNT_CONVERGE_FLOOR_S \
+  -e LOAD_PAUSE_TIMEOUT_S \
+  -e NEIGHBOUR_LOAD_OPS_PER_SECOND \
+  -e RESTORE_NODE_MAPPING \
+  -e RESTORE_INCLUDE \
+  -t namespace_graduation python3 run.py "$MODE")
+
+echo "Following the logs until ${MODE} completes"
+docker logs -ft "$container_id"
+
+# `docker wait` blocks until the container stops and prints its exit code, so a broken log stream
+# cannot read a still-running container's ExitCode as 0. It returns immediately once it has stopped.
+exit_code=$(docker wait "$container_id")
+echo "Container exited with code $exit_code"
+exit "$exit_code"


### PR DESCRIPTION
This adds an end-to-end test of namespace graduation: moving a single namespace off a shared namespaced cluster onto its own dedicated cluster using backup and restore, then scaling the migrated collections from one replica to three. The test provisions its own clusters with docker compose and runs with one command against Weaviate stable/v1.38.

## What's being changed

- New app `apps/namespace-graduation/`: seeds a graduating namespace plus two neighbours (users, roles, collections, vectors), keeps writing to the neighbours throughout, backs up the graduating namespace by wildcard, restores it onto the bare target cluster, scales every migrated collection to three replicas, deletes the source namespace, and asserts everything.
- The assertions are strict by design: every object is read back from each of the three target replicas individually, every migrated user logs in with its original key and is checked for exactly its prior capabilities (allowed actions succeed, disallowed actions are denied), neighbour namespaces are compared object by object before and after the source deletion, and nothing neighbour-owned may appear on the target.
- Two new compose files under `apps/weaviate/`: a single-node namespaced source and a 3-node replicated target, sharing one minio backup backend. The existing compose files they mimic are not modified.
- New root script `namespace_graduation.sh`: brings up both clusters and minio, waits for real readiness (including the bucket creation one-shot), runs the test container in `preflight` (seconds, writes nothing) or `journey` mode, streams logs, dumps cluster logs on failure before teardown, and cleans up after itself. `KEEP_CLUSTERS=1` preserves the rig for debugging.
- No existing file in the repository is modified.

## Motivation and Context

- Namespace graduation is the customer journey for promoting a namespace to a dedicated cluster. No test covered it in core or in this repository before this one.
- The test found the core bug on its first full live run, and its failure messages localise the mechanism: restored users authenticate on one node while the cluster-wide user list stays empty, and consecutive runs show two distinct failure shapes (empty stores versus roles arriving unstripped from every namespace), which points at the restore applying locally on the coordinating node rather than through RAFT.
- Evidence for the core issue lives in the development run's logs (journey runs 3 and 4), alongside the wiring citations in `usecases/backup/restorer.go` and `adapters/handlers/rest/configure_api.go`.
- Follow-up work already scoped: a node-kill chaos variant of this journey, and a standing check that the first run after the core fix shows the negative permission probe firing.