### PR TITLE
ci: disable AWS ANN benchmark jobs

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -288,7 +288,7 @@ jobs:
       - uses: psf/black@26.1.0
   ann-benchmarks-sift-aws:
     name: "[bench AWS] SIFT1M pq=false"
-    if: ${{ inputs.lsm_access_strategy == 'pread' && (github.event.inputs.test_to_run == 'ann-benchmarks-sift-aws' || github.event.inputs.test_to_run == '') }}
+    if: false # disabled: AWS ANN benchmarks turned off
     runs-on: ubicloud-standard-2
     timeout-minutes: 60
     env:
@@ -326,7 +326,7 @@ jobs:
           glob: '*.json'
   ann-benchmarks-glove-aws:
     name: "[bench AWS] Glove100 pq=false"
-    if: ${{ inputs.lsm_access_strategy == 'pread' && (github.event.inputs.test_to_run == 'ann-benchmarks-glove-aws' || github.event.inputs.test_to_run == '') }}
+    if: false # disabled: AWS ANN benchmarks turned off
     runs-on: ubicloud-standard-2
     timeout-minutes: 60
     env:
@@ -364,7 +364,7 @@ jobs:
           glob: '*.json'
   ann-benchmarks-pq-sift-aws:
     name: "[bench AWS] SIFT1M pq=true"
-    if: ${{ inputs.lsm_access_strategy == 'pread' && (github.event.inputs.test_to_run == 'ann-benchmarks-pq-sift-aws' || github.event.inputs.test_to_run == '') }}
+    if: false # disabled: AWS ANN benchmarks turned off
     runs-on: ubicloud-standard-2
     timeout-minutes: 60
     env:
@@ -403,7 +403,7 @@ jobs:
           glob: '*.json'
   ann-benchmarks-sq-sift-aws:
     needs: [newer-or-equal-than-1_26]
-    if: ${{ inputs.lsm_access_strategy == 'pread' && (needs.newer-or-equal-than-1_26.outputs.check == 'true') && (github.event.inputs.test_to_run == 'ann-benchmarks-sq-sift-aws' || github.event.inputs.test_to_run == '')}}
+    if: false # disabled: AWS ANN benchmarks turned off
     name: "[bench AWS] SIFT1M sq=true"
     runs-on: ubicloud-standard-2
     timeout-minutes: 60
@@ -443,7 +443,7 @@ jobs:
           glob: '*.json'
   ann-benchmarks-pq-glove-aws:
     name: "[bench AWS] Glove100 pq=true"
-    if: ${{ inputs.lsm_access_strategy == 'pread' && (github.event.inputs.test_to_run == 'ann-benchmarks-pq-glove-aws' || github.event.inputs.test_to_run == '') }}
+    if: false # disabled: AWS ANN benchmarks turned off
     runs-on: ubicloud-standard-2
     timeout-minutes: 60
     env:
@@ -482,7 +482,7 @@ jobs:
           glob: '*.json'
   ann-benchmarks-sq-glove-aws:
     needs: [newer-or-equal-than-1_26]
-    if: ${{ inputs.lsm_access_strategy == 'pread' && (needs.newer-or-equal-than-1_26.outputs.check == 'true') && ( github.event.inputs.test_to_run == 'ann-benchmarks-sq-glove-aws' || github.event.inputs.test_to_run == '' ) }}
+    if: false # disabled: AWS ANN benchmarks turned off
     name: "[bench AWS] Glove100 sq=true"
     runs-on: ubicloud-standard-2
     timeout-minutes: 60
@@ -523,7 +523,7 @@ jobs:
 
   ann-benchmarks-rq-glove-aws:
     needs: [newer-or-equal-than-1_32]
-    if: ${{ inputs.lsm_access_strategy == 'pread' && (needs.newer-or-equal-than-1_32.outputs.check == 'true') && (github.event.inputs.test_to_run == 'ann-benchmarks-rq-glove-aws' || github.event.inputs.test_to_run == '') }}
+    if: false # disabled: AWS ANN benchmarks turned off
     name: "[bench AWS] Glove100 rq=true"
     runs-on: ubicloud-standard-2
     timeout-minutes: 60


### PR DESCRIPTION
Turns off the seven `[bench AWS]` ANN benchmark jobs (`sift`, `glove`, and their pq/sq/rq quantization variants), as requested. These jobs provision real EC2 instances via `ann_benchmark_aws.sh` / `ann_benchmark_quantization_aws.sh` on every full matrix run.

Each job's `if:` condition is replaced with `if: false` plus a comment, following the existing convention in this workflow (see the retired GCP SIFT jobs). The job definitions, `needs:` chains, and AWS scripts stay in place and the original trigger conditions remain in git history, so re-enabling any job is a one-line revert. No other jobs depend on the disabled ones, so nothing downstream is affected.

**Risks**: none beyond losing the benchmark signal itself — with these off, SIFT1M and Glove100 coverage stops entirely (only the multivector GCP benchmarks remain active). `test_to_run` selections targeting these jobs will simply produce a skipped job rather than a failure.