### PR TITLE
fix: shorten drop-vector reconcile interval in alter-schema CI job

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -2733,7 +2733,7 @@ jobs:
           replicas: '3'
           weaviate-version: ${{env.WEAVIATE_VERSION}}
           modules: 'text2vec-model2vec'
-          values-inline: '--set env.PERSISTENCE_LSM_ACCESS_STRATEGY=${{env.PERSISTENCE_LSM_ACCESS_STRATEGY}} --set env.ENABLE_EXPERIMENTAL_ALTER_SCHEMA_DROP_VECTOR_INDEX_ENDPOINT=true'
+          values-inline: '--set env.PERSISTENCE_LSM_ACCESS_STRATEGY=${{env.PERSISTENCE_LSM_ACCESS_STRATEGY}} --set env.ENABLE_EXPERIMENTAL_ALTER_SCHEMA_DROP_VECTOR_INDEX_ENDPOINT=true --set env.DROP_VECTOR_INDEX_RECONCILE_INTERVAL_SECONDS=30'
       - name: Run alter schema drop vector index tests
         run: apps/alter_schema_operations/alter_schema_drop_vector_index.sh
       - name: Archive logs

--- a/apps/alter_schema_operations/drop_vector_indexes_mt_test.go
+++ b/apps/alter_schema_operations/drop_vector_indexes_mt_test.go
@@ -164,10 +164,11 @@ func TestActivateTenant3MoviesMT(t *testing.T) {
 		})
 	}
 
-	// tenant3 was a cold (inactive) tenant during the drop. As of the cold-tenant
-	// cleanup fix, reactivating it must also remove the dropped vectors from its
-	// objects. Cleanup is triggered on activation and runs through a rate-limited
-	// cleanup cycle, so we allow a longer timeout than the active-tenant case.
+	// tenant3 was a cold (inactive) tenant during the drop, so the drop task did
+	// not cover its shard. Activation does not trigger cleanup; the periodic
+	// drop-vector reconcile round picks the shard up later (default interval 15m,
+	// set to 30s in CI via DROP_VECTOR_INDEX_RECONCILE_INTERVAL_SECONDS), so we
+	// allow a longer timeout than the active-tenant case.
 	for _, vectorName := range moviesMTVectorizerVectors {
 		t.Run("verify_vector_removed_from_objects_after_activation_tenant3_"+vectorName, func(t *testing.T) {
 			assertObjectsLackNamedVectorWithin(ctx, t, client, moviesMTClass, "tenant3", vectorName, coldTenantVectorCleanupTimeout)


### PR DESCRIPTION
## Motivation

The `alter-schema-drop-vector-index` job is flaky: [run 32431185604](https://github.com/weaviate/weaviate-chaos-engineering/actions/runs/32431185604/job/96623147340) (pread) timed out while the mmap sibling job passed on the same nightly image.

The cold-tenant subtest of `TestActivateTenant3MoviesMT` waits for dropped vectors to be cleaned from tenant3, which was inactive during the drop. The server does not start cleanup on tenant activation: the drop task only covers tenants that were active at drop time, and inactive tenants are picked up by the periodic drop-vector reconcile round, whose default interval is 15 minutes (`DefaultDropVectorReconcileInterval`). That is longer than the test's 5-min-per-vector budget and the 15-min go-test timeout.

Each completed cleanup task nudges the reconcile loop once, ~3s later. If the nudge fires before tenant3 is reactivated, the loop sees no active uncovered tenant and sleeps the full 15 minutes — the failed run lost this race; the passing mmap job won it (cleanup finished 16s after activation). The lsm access strategy is not causal.

## Change

- Set `DROP_VECTOR_INDEX_RECONCILE_INTERVAL_SECONDS=30` in the job's helm values, so cleanup for the reactivated tenant starts within ~30s regardless of the nudge race.
- Correct the test comment that claimed cleanup is triggered on activation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)